### PR TITLE
fix: normalize timeBucket to ISO-8601 for Immich v2 API compatibility

### DIFF
--- a/lib/Service/ImmichService.php
+++ b/lib/Service/ImmichService.php
@@ -174,6 +174,11 @@ class ImmichService {
     }
 
     public function getTimelineBucket(string $timeBucket, string $size = 'MONTH', ?string $personId = null, ?string $assetType = null, bool $isFavorite = false): array {
+        // Immich v2 requires ISO-8601 format (YYYY-MM-DDTHH:MM:SS.000Z) for timeBucket.
+        // Older API responses returned short dates (YYYY-MM-DD); normalize them here.
+        if (strlen($timeBucket) === 10) {
+            $timeBucket .= 'T00:00:00.000Z';
+        }
         $query = ['timeBucket' => $timeBucket, 'size' => $size];
         if ($personId !== null && $personId !== '') {
             $query['personId'] = $personId;
@@ -332,7 +337,7 @@ class ImmichService {
             }
             $raw = $this->request('GET', '/timeline/bucket', [
                 'query' => [
-                    'timeBucket' => $timeBucket,
+                    'timeBucket' => (strlen($timeBucket) === 10 ? $timeBucket . 'T00:00:00.000Z' : $timeBucket),
                     'size' => 'MONTH',
                     'personId' => $id,
                 ],


### PR DESCRIPTION
## Problem

With Immich v2, the `/api/timeline/bucket` endpoint requires the `timeBucket` parameter in full ISO-8601 format (`YYYY-MM-DDTHH:MM:SS.000Z`). However, the `/api/timeline/buckets` endpoint returns `timeBucket` values in short date format (`YYYY-MM-DD`), and that value is passed directly to `/timeline/bucket` without normalization.

This causes `/timeline/bucket` to silently return empty columnar arrays (`{"id":[],"...":[]}`), resulting in **no photos being displayed** in the Nextcloud plugin — despite the API key being valid and Immich containing assets.

## Root Cause

`ImmichService::getTimelineBucket()` and the person-asset loop in `getPersonAssets()` both pass `timeBucket` straight to the query without validating its format.

**Request that returns 0 assets:**
```
GET /api/timeline/bucket?timeBucket=2023-11-01&size=MONTH
→ {"id":[],"stack":[],...}  (all arrays empty)
```

**Request that returns assets correctly:**
```
GET /api/timeline/bucket?timeBucket=2023-11-01T00:00:00.000Z&size=MONTH
→ {"id":["uuid1","uuid2",...],...}
```

## Fix

Normalize any 10-character `YYYY-MM-DD` date string to `YYYY-MM-DDTHH:MM:SS.000Z` before passing it to the API. Applied in two places:

1. `getTimelineBucket()` — handles all standard timeline views (All Media, Favorites, etc.)
2. Person-asset loop in `getPersonAssets()` — handles People view

The normalization is backwards-compatible: if Immich ever returns full ISO-8601 strings from `/timeline/buckets`, the `strlen === 10` guard ensures no double-appending.

## Tested Against

- Immich **v2.7.5**
- Nextcloud plugin `integration_immich` **v1.1.3**
- All media view: ✅ thumbnails load correctly after fix
- People view: ✅ person assets load correctly after fix