### PR TITLE
feat: Masonry grid layout + album timeline buckets + place search

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -28,6 +28,7 @@ return [
         ['name' => 'assets#original',        'url' => '/api/v1/assets/{id}/original',        'verb' => 'GET'],
         ['name' => 'assets#videoStream',     'url' => '/api/v1/assets/{id}/video',           'verb' => 'GET'],
         ['name' => 'assets#mapMarkers',      'url' => '/api/v1/map/markers',                 'verb' => 'GET'],
+        ['name' => 'assets#searchLocation',  'url' => '/api/v1/search/location',             'verb' => 'GET'],
         ['name' => 'assets#explore',         'url' => '/api/v1/explore',                     'verb' => 'GET'],
 
         // Albums

--- a/lib/Controller/AssetsController.php
+++ b/lib/Controller/AssetsController.php
@@ -60,12 +60,13 @@ class AssetsController extends Controller {
             $timeBucket = $this->request->getParam('timeBucket');
             $size = $this->request->getParam('size', 'MONTH');
             $personId = $this->request->getParam('personId');
+            $albumId = $this->request->getParam('albumId');
             $assetType = $this->request->getParam('assetType');
             $isFavoriteParam = $this->request->getParam('isFavorite');
             $isFavorite = $isFavoriteParam === 'true';
 
             if ($timeBucket) {
-                $data = $this->immichService->getTimelineBucket($timeBucket, $size, $personId, null, $isFavorite);
+                $data = $this->immichService->getTimelineBucket($timeBucket, $size, $personId, $albumId, null, $isFavorite);
                 // Immich timeline/bucket does not support assetType filtering.
                 // Immich returns isImage (bool) instead of a type field — filter in PHP.
                 if ($assetType === 'IMAGE') {
@@ -80,7 +81,7 @@ class AssetsController extends Controller {
                     ));
                 }
             } else {
-                $data = $this->immichService->getTimelineBuckets($size, $personId, null, $isFavorite);
+                $data = $this->immichService->getTimelineBuckets($size, $personId, $albumId, null, $isFavorite);
             }
 
             return new JSONResponse($data);
@@ -246,6 +247,35 @@ class AssetsController extends Controller {
             return new JSONResponse($markers);
         } catch (\Exception $e) {
             return $this->errorResponse('map markers', $e);
+        }
+    }
+
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function searchLocation(): JSONResponse {
+        if (!$this->immichService->isConfigured()) {
+            return new JSONResponse(
+                ['error' => 'Immich is not configured'],
+                Http::STATUS_PRECONDITION_FAILED
+            );
+        }
+
+        $field = $this->request->getParam('field', '');
+        $value = $this->request->getParam('value', '');
+        if ($field === '' || $value === '') {
+            return new JSONResponse(['error' => 'field and value are required'], Http::STATUS_BAD_REQUEST);
+        }
+
+        $allowedFields = ['exifInfo.city', 'exifInfo.country', 'exifInfo.state', 'city', 'country', 'state'];
+        if (!in_array($field, $allowedFields, true)) {
+            return new JSONResponse(['error' => 'Invalid field'], Http::STATUS_BAD_REQUEST);
+        }
+
+        try {
+            $data = $this->immichService->searchByLocation($field, $value);
+            return new JSONResponse($data);
+        } catch (\Exception $e) {
+            return $this->errorResponse('search location', $e);
         }
     }
 

--- a/lib/Service/ImmichService.php
+++ b/lib/Service/ImmichService.php
@@ -196,10 +196,13 @@ class ImmichService {
         return $missing;
     }
 
-    public function getTimelineBuckets(string $size = 'MONTH', ?string $personId = null, ?string $assetType = null, bool $isFavorite = false): array {
+    public function getTimelineBuckets(string $size = 'MONTH', ?string $personId = null, ?string $albumId = null, ?string $assetType = null, bool $isFavorite = false): array {
         $query = ['size' => $size];
         if ($personId !== null && $personId !== '') {
             $query['personId'] = $personId;
+        }
+        if ($albumId !== null && $albumId !== '') {
+            $query['albumId'] = $albumId;
         }
         if ($assetType !== null && $assetType !== '') {
             $query['assetType'] = $assetType;
@@ -210,7 +213,7 @@ class ImmichService {
         return $this->request('GET', '/timeline/buckets', ['query' => $query]);
     }
 
-    public function getTimelineBucket(string $timeBucket, string $size = 'MONTH', ?string $personId = null, ?string $assetType = null, bool $isFavorite = false): array {
+    public function getTimelineBucket(string $timeBucket, string $size = 'MONTH', ?string $personId = null, ?string $albumId = null, ?string $assetType = null, bool $isFavorite = false): array {
         // Immich v2 requires ISO-8601 format (YYYY-MM-DDTHH:MM:SS.000Z) for timeBucket.
         // Older API responses returned short dates (YYYY-MM-DD); normalize them here.
         if (strlen($timeBucket) === 10) {
@@ -219,6 +222,9 @@ class ImmichService {
         $query = ['timeBucket' => $timeBucket, 'size' => $size];
         if ($personId !== null && $personId !== '') {
             $query['personId'] = $personId;
+        }
+        if ($albumId !== null && $albumId !== '') {
+            $query['albumId'] = $albumId;
         }
         if ($assetType !== null && $assetType !== '') {
             $query['assetType'] = $assetType;
@@ -395,6 +401,33 @@ class ImmichService {
         return $this->request('GET', '/map/markers', [
             'query' => ['isArchived' => 'false'],
         ]);
+    }
+
+    /**
+     * Search assets by location field (city / country / state).
+     * Uses Immich's POST /search/metadata to return AssetResponseDto objects
+     * with width + height — which getItemRatio() in the frontend can use for masonry.
+     */
+    public function searchByLocation(string $field, string $value): array {
+        // Map frontend field paths (e.g. "exifInfo.city") to MetadataSearchDto keys.
+        $fieldMap = [
+            'exifInfo.city'    => 'city',
+            'exifInfo.country' => 'country',
+            'exifInfo.state'   => 'state',
+            'city'             => 'city',
+            'country'          => 'country',
+            'state'            => 'state',
+        ];
+        $key = $fieldMap[$field] ?? $field;
+
+        $body = [
+            $key         => $value,
+            'isArchived' => false,
+            'size'       => 1000,
+        ];
+
+        $result = $this->request('POST', '/search/metadata', ['body' => $body]);
+        return $result['assets']['items'] ?? [];
     }
 
     // ---- Explore ----

--- a/src/components/AlbumDetailView.vue
+++ b/src/components/AlbumDetailView.vue
@@ -1,5 +1,7 @@
 <!--
-  - SPDX-FileCopyrightText: 2026 Marcel Meyer <gh@grenzallee.eu>
+  - SPDX-FileCopyrightText: 202					<NcButton v-if="totalCount > 0"
+						variant="secondary"
+						@click="showPicker = true">arcel Meyer <gh@grenzallee.eu>
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
@@ -73,6 +75,7 @@
 							class="album-detail__layout-btn"
 							:class="{ 'album-detail__layout-btn--active': store.gridLayout === 'grid' }"
 							:title="t('integration_immich', 'Square grid')"
+							:aria-label="t('integration_immich', 'Square grid')"
 							@click="store.setGridLayout('grid')">
 							<ViewGridIcon :size="16" />
 						</button>
@@ -80,6 +83,7 @@
 							class="album-detail__layout-btn"
 							:class="{ 'album-detail__layout-btn--active': store.gridLayout === 'masonry' }"
 							:title="t('integration_immich', 'Masonry grid')"
+							:aria-label="t('integration_immich', 'Masonry grid')"
 							@click="store.setGridLayout('masonry')">
 							<ViewQuiltIcon :size="16" />
 						</button>
@@ -253,7 +257,10 @@ function estimateBucketHeightMasonry(count, assets = null) {
 		for (const asset of assets) {
 			const ratio = (asset.ratio > 0) ? asset.ratio : MASONRY_DEFAULT_RATIO
 			const itemHeight = colWidth / ratio
-			const minIdx = columnHeights.indexOf(Math.min(...columnHeights))
+			let minIdx = 0
+			for (let i = 1; i < columnHeights.length; i++) {
+				if (columnHeights[i] < columnHeights[minIdx]) minIdx = i
+			}
 			columnHeights[minIdx] += itemHeight + GRID_GAP
 		}
 		return HEADER_HEIGHT + Math.max(...columnHeights)
@@ -472,6 +479,9 @@ onMounted(() => {
 
 watch(() => props.id, () => {
 	if (scrollContainer.value) scrollContainer.value.scrollTop = 0
+	scrollTop.value = 0
+	pendingQueue.length = 0
+	activeRequests = 0
 	load()
 })
 
@@ -549,6 +559,11 @@ onBeforeUnmount(() => {
 .album-detail__layout-btn:hover {
 	color: var(--color-main-text);
 	background: var(--color-background-hover);
+}
+
+.album-detail__layout-btn:focus-visible {
+	outline: 2px solid var(--color-primary);
+	outline-offset: 2px;
 }
 
 .album-detail__layout-btn--active {

--- a/src/components/AlbumDetailView.vue
+++ b/src/components/AlbumDetailView.vue
@@ -4,7 +4,7 @@
 -->
 <template>
 	<div class="album-detail">
-		<NcLoadingIcon v-if="store.loading && !store.currentAlbum"
+		<NcLoadingIcon v-if="store.loading && !store.currentAlbum && store.albumBuckets.length === 0"
 			:size="64"
 			class="album-detail__loading" />
 
@@ -53,7 +53,7 @@
 								</template>
 								{{ t('integration_immich', 'Rename') }}
 							</NcActionButton>
-							<NcActionButton v-if="store.currentAlbum.assets && store.currentAlbum.assets.length > 0"
+							<NcActionButton v-if="totalCount > 0"
 								@click="showPicker = true">
 								<template #icon>
 									<ImagePlusIcon :size="20" />
@@ -63,10 +63,28 @@
 						</NcActions>
 					</div>
 				</div>
-				<!-- Photo count below breadcrumb -->
-				<span class="album-detail__count">
-					{{ t('integration_immich', '{count} photos', { count: store.currentAlbum.assets?.length || 0 }) }}
-				</span>
+				<!-- Photo count + layout toggle below breadcrumb -->
+				<div class="album-detail__meta-row">
+					<span class="album-detail__count">
+						{{ t('integration_immich', '{count} photos', { count: totalCount }) }}
+					</span>
+					<div class="album-detail__layout-toggle">
+						<button
+							class="album-detail__layout-btn"
+							:class="{ 'album-detail__layout-btn--active': store.gridLayout === 'grid' }"
+							:title="t('integration_immich', 'Square grid')"
+							@click="store.setGridLayout('grid')">
+							<ViewGridIcon :size="16" />
+						</button>
+						<button
+							class="album-detail__layout-btn"
+							:class="{ 'album-detail__layout-btn--active': store.gridLayout === 'masonry' }"
+							:title="t('integration_immich', 'Masonry grid')"
+							@click="store.setGridLayout('masonry')">
+							<ViewQuiltIcon :size="16" />
+						</button>
+					</div>
+				</div>
 			</div>
 
 			<!-- Rename Dialog -->
@@ -96,27 +114,50 @@
 			</NcDialog>
 
 			<!-- Scroll-Bereich -->
-			<div class="album-detail__scroll">
-				<NcEmptyContent v-if="!store.currentAlbum.assets || store.currentAlbum.assets.length === 0"
-					:name="t('integration_immich', 'Album is empty')"
-					:description="t('integration_immich', 'This album does not contain any photos yet.')">
-					<template #icon>
-						<ImageIcon :size="64" />
-					</template>
-					<template #action>
-						<NcButton variant="primary" @click="showPicker = true">
-							<template #icon>
-								<ImagePlusIcon :size="20" />
-							</template>
-							{{ t('integration_immich', 'Add photos') }}
-						</NcButton>
-					</template>
-				</NcEmptyContent>
+			<NcEmptyContent v-if="store.albumBuckets.length === 0 && !store.loading"
+				:name="t('integration_immich', 'Album is empty')"
+				:description="t('integration_immich', 'This album does not contain any photos yet.')">
+				<template #icon>
+					<ImageIcon :size="64" />
+				</template>
+				<template #action>
+					<NcButton variant="primary" @click="showPicker = true">
+						<template #icon>
+							<ImagePlusIcon :size="20" />
+						</template>
+						{{ t('integration_immich', 'Add photos') }}
+					</NcButton>
+				</template>
+			</NcEmptyContent>
 
-				<PhotoGrid v-else
-					:assets="store.currentAlbum.assets"
-					:selectable="true"
-					@click="(_, idx) => store.openLightbox(store.currentAlbum.assets, idx)" />
+			<div v-else
+				ref="scrollContainer"
+				class="album-detail__scroll"
+				@scroll="onScroll">
+				<!-- Sticky date bar -->
+				<div class="album-detail__sticky-date">
+					<span class="album-detail__sticky-label">{{ currentBucketLabel }}</span>
+					<span v-if="currentBucketCount" class="album-detail__sticky-count">{{ currentBucketCount }}</span>
+				</div>
+
+				<div class="album-detail__runway" :style="{ height: totalHeight + 'px' }">
+					<div v-for="index in windowIndices"
+						:key="store.albumBuckets[index].timeBucket"
+						class="album-detail__bucket"
+						:style="{ transform: `translateY(${bucketOffsets[index]}px)` }">
+						<NcLoadingIcon v-if="loadingSet.has(store.albumBuckets[index].timeBucket)"
+							:size="32"
+							class="album-detail__bucket-loading" />
+						<PhotoGrid v-else-if="store.albumBucketAssets[store.albumBuckets[index].timeBucket]"
+							:assets="store.albumBucketAssets[store.albumBuckets[index].timeBucket]"
+							:selectable="true"
+							:layout="store.gridLayout"
+							@click="(_, idx) => openLightboxFromBucket(idx, index)" />
+						<div v-else
+							class="album-detail__bucket-placeholder"
+							:style="{ height: (bucketHeights[index] - HEADER_HEIGHT) + 'px' }" />
+					</div>
+				</div>
 			</div>
 
 			<!-- Asset Picker Overlay für "Bilder hinzufügen" -->
@@ -131,7 +172,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { NcButton, NcEmptyContent, NcLoadingIcon, NcDialog, NcTextField, NcActions, NcActionButton, NcBreadcrumbs, NcBreadcrumb } from '@nextcloud/vue'
 import { translate as t } from '@nextcloud/l10n'
@@ -145,6 +186,9 @@ import ImageIcon from 'vue-material-design-icons/Image.vue'
 import ImagePlusIcon from 'vue-material-design-icons/ImagePlus.vue'
 import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
+import ViewGridIcon from 'vue-material-design-icons/ViewGrid.vue'
+import ViewQuiltIcon from 'vue-material-design-icons/ViewQuilt.vue'
+
 const props = defineProps({
 	id: {
 		type: String,
@@ -160,17 +204,198 @@ const showRenameDialog = ref(false)
 const renameValue = ref('')
 const renaming = ref(false)
 
+// --- Constants (same pattern as PersonDetailView) ---
+const HEADER_HEIGHT = 40
+const GRID_MIN_ITEM = 180
+const GRID_GAP = 3
+const BUCKET_PADDING_LR = 32
+const OVERSCAN = 800
+const MAX_CONCURRENT = 2
+const MAX_LOADED_BUCKETS = 12
+const MASONRY_DEFAULT_RATIO = 1.0
+
+// --- Reactive state ---
+const scrollContainer = ref(null)
+const scrollTop = ref(0)
+const viewportHeight = ref(800)
+const containerWidth = ref(0)
+const loadingSet = ref(new Set())
+
+let activeRequests = 0
+const pendingQueue = []
+let resizeObserver = null
+
+// --- Computed ---
+const totalCount = computed(() =>
+	store.albumBuckets.reduce((sum, b) => sum + (b.count || 0), 0),
+)
+
 // IDs der bereits im Album enthaltenen Assets → werden im Picker grau markiert
 const existingAssetIds = computed(() =>
 	new Set((store.currentAlbum?.assets ?? []).map(a => a.id))
 )
 
-function goBack() {
-	router.push({ name: 'albums' })
+function estimateBucketHeight(count) {
+	const available = Math.max(GRID_MIN_ITEM, containerWidth.value - BUCKET_PADDING_LR)
+	const cols = Math.max(1, Math.floor((available + GRID_GAP) / (GRID_MIN_ITEM + GRID_GAP)))
+	const colWidth = (available - (cols - 1) * GRID_GAP) / cols
+	const rows = Math.ceil(count / cols)
+	return HEADER_HEIGHT + rows * colWidth + (rows - 1) * GRID_GAP
 }
 
-function loadAlbum() {
-	store.fetchAlbum(props.id)
+function estimateBucketHeightMasonry(count, assets = null) {
+	const available = Math.max(GRID_MIN_ITEM, containerWidth.value - BUCKET_PADDING_LR)
+	const cols = Math.max(1, Math.floor((available + GRID_GAP) / (GRID_MIN_ITEM + GRID_GAP)))
+	const colWidth = (available - (cols - 1) * GRID_GAP) / cols
+
+	if (assets && assets.length > 0) {
+		const columnHeights = new Array(cols).fill(0)
+		for (const asset of assets) {
+			const ratio = (asset.ratio > 0) ? asset.ratio : MASONRY_DEFAULT_RATIO
+			const itemHeight = colWidth / ratio
+			const minIdx = columnHeights.indexOf(Math.min(...columnHeights))
+			columnHeights[minIdx] += itemHeight + GRID_GAP
+		}
+		return HEADER_HEIGHT + Math.max(...columnHeights)
+	}
+
+	const itemHeight = colWidth / MASONRY_DEFAULT_RATIO
+	const rows = Math.ceil(count / cols)
+	return HEADER_HEIGHT + rows * (itemHeight + GRID_GAP)
+}
+
+const bucketHeights = computed(() =>
+	store.albumBuckets.map(b => {
+		if (store.gridLayout === 'masonry') {
+			return estimateBucketHeightMasonry(b.count, store.albumBucketAssets[b.timeBucket])
+		}
+		return estimateBucketHeight(b.count)
+	}),
+)
+
+const bucketOffsets = computed(() => {
+	const offsets = []
+	let cumulative = 0
+	for (let i = 0; i < bucketHeights.value.length; i++) {
+		offsets.push(cumulative)
+		cumulative += bucketHeights.value[i]
+	}
+	return offsets
+})
+
+const totalHeight = computed(() => {
+	const h = bucketHeights.value
+	if (h.length === 0) return 0
+	return bucketOffsets.value[h.length - 1] + h[h.length - 1]
+})
+
+const windowIndices = computed(() => {
+	if (store.albumBuckets.length === 0) return []
+	const top = scrollTop.value - OVERSCAN
+	const bottom = scrollTop.value + viewportHeight.value + OVERSCAN
+	const indices = []
+	for (let i = 0; i < store.albumBuckets.length; i++) {
+		const bTop = bucketOffsets.value[i]
+		const bBottom = bTop + bucketHeights.value[i]
+		if (bBottom >= top && bTop <= bottom) indices.push(i)
+		if (bTop > bottom) break
+	}
+	return indices
+})
+
+// --- Scroll handler ---
+let scrollRaf = null
+function onScroll() {
+	if (scrollRaf) return
+	scrollRaf = requestAnimationFrame(() => {
+		if (scrollContainer.value) {
+			scrollTop.value = scrollContainer.value.scrollTop
+			viewportHeight.value = scrollContainer.value.clientHeight
+		}
+		scrollRaf = null
+	})
+}
+
+// --- Sticky date label (which bucket is at top of viewport) ---
+const currentBucket = computed(() => {
+	if (store.albumBuckets.length === 0) return null
+	let idx = 0
+	for (let i = 0; i < bucketOffsets.value.length; i++) {
+		if (bucketOffsets.value[i] <= scrollTop.value) idx = i
+		else break
+	}
+	return store.albumBuckets[idx]
+})
+
+const currentBucketLabel = computed(() =>
+	currentBucket.value ? formatBucketDate(currentBucket.value.timeBucket) : ''
+)
+
+const currentBucketCount = computed(() =>
+	currentBucket.value?.count ?? 0
+)
+
+// --- Lazy bucket loading ---
+async function loadBucket(timeBucket) {
+	if (store.albumBucketAssets[timeBucket] || loadingSet.value.has(timeBucket)) return
+
+	if (activeRequests >= MAX_CONCURRENT) {
+		return new Promise(resolve => {
+			pendingQueue.push(() => loadBucket(timeBucket).then(resolve))
+		})
+	}
+
+	activeRequests++
+	loadingSet.value = new Set([...loadingSet.value, timeBucket])
+	try {
+		await store.fetchAlbumBucketAssets(props.id, timeBucket)
+	} finally {
+		loadingSet.value = new Set([...loadingSet.value].filter(b => b !== timeBucket))
+		activeRequests--
+		if (pendingQueue.length > 0) pendingQueue.shift()()
+	}
+}
+
+function evictDistantBuckets(currentIndices) {
+	const loadedKeys = Object.keys(store.albumBucketAssets)
+	if (loadedKeys.length <= MAX_LOADED_BUCKETS) return
+	const visibleKeys = new Set(currentIndices.map(i => store.albumBuckets[i].timeBucket))
+	for (const key of loadedKeys) {
+		if (visibleKeys.has(key)) continue
+		if (Object.keys(store.albumBucketAssets).length <= MAX_LOADED_BUCKETS) break
+		store.unloadAlbumBucketAsset(key)
+	}
+}
+
+watch(windowIndices, (indices) => {
+	for (const i of indices) {
+		const bucket = store.albumBuckets[i]
+		if (bucket && !store.albumBucketAssets[bucket.timeBucket]) {
+			loadBucket(bucket.timeBucket)
+		}
+	}
+	evictDistantBuckets(indices)
+}, { immediate: true })
+
+function openLightboxFromBucket(localIdx, bucketIndex) {
+	const allAssets = []
+	let globalIdx = 0
+	for (let i = 0; i < store.albumBuckets.length; i++) {
+		const bucketAssets = store.albumBucketAssets[store.albumBuckets[i].timeBucket]
+		if (!bucketAssets) continue
+		if (i === bucketIndex) globalIdx = allAssets.length + localIdx
+		allAssets.push(...bucketAssets)
+	}
+	store.openLightbox(allAssets, globalIdx)
+}
+
+function formatBucketDate(timeBucket) {
+	const date = new Date(timeBucket)
+	return date.toLocaleDateString(undefined, { year: 'numeric', month: 'long' })
+}
+
+function goBack() {
+	router.push({ name: 'albums' })
 }
 
 function startRename() {
@@ -212,7 +437,7 @@ async function addAssetsToAlbum(assetIds) {
 		} else {
 			showError(t('integration_immich', 'Error adding to album'))
 		}
-		await store.fetchAlbum(props.id)
+		await Promise.all([store.fetchAlbum(props.id), store.fetchAlbumBuckets(props.id)])
 	} catch (e) {
 		showError(t('integration_immich', 'Error adding: {msg}', { msg: e.message }))
 	} finally {
@@ -220,12 +445,41 @@ async function addAssetsToAlbum(assetIds) {
 	}
 }
 
+watch(scrollContainer, (el) => {
+	resizeObserver?.disconnect()
+	resizeObserver = null
+	if (el) {
+		containerWidth.value = el.clientWidth
+		viewportHeight.value = el.clientHeight
+		resizeObserver = new ResizeObserver(([entry]) => {
+			containerWidth.value = entry.contentRect.width
+			viewportHeight.value = entry.contentRect.height
+		})
+		resizeObserver.observe(el)
+	}
+})
+
+async function load() {
+	await Promise.all([
+		store.fetchAlbum(props.id),
+		store.fetchAlbumBuckets(props.id),
+	])
+}
+
 onMounted(() => {
-	loadAlbum()
+	load()
 })
 
 watch(() => props.id, () => {
-	loadAlbum()
+	if (scrollContainer.value) scrollContainer.value.scrollTop = 0
+	load()
+})
+
+onBeforeUnmount(() => {
+	if (scrollRaf) cancelAnimationFrame(scrollRaf)
+	resizeObserver?.disconnect()
+	pendingQueue.length = 0
+	activeRequests = 0
 })
 </script>
 
@@ -264,11 +518,102 @@ watch(() => props.id, () => {
 	margin-top: 2px;
 }
 
+/* Row combining photo count + layout toggle */
+.album-detail__meta-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 2px;
+}
+
+.album-detail__layout-toggle {
+	margin-left: auto;
+	display: flex;
+	gap: 2px;
+}
+
+.album-detail__layout-btn {
+	all: unset;
+	box-sizing: border-box;
+	width: 28px;
+	height: 28px;
+	border-radius: 6px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	color: var(--color-text-maxcontrast);
+	transition: color 0.15s ease, background 0.15s ease;
+}
+
+.album-detail__layout-btn:hover {
+	color: var(--color-main-text);
+	background: var(--color-background-hover);
+}
+
+.album-detail__layout-btn--active {
+	color: var(--color-primary);
+	background: var(--color-primary-element-light);
+}
+
 .album-detail__scroll {
 	flex: 1;
 	overflow-y: auto;
+	position: relative;
+}
+
+.album-detail__sticky-date {
+	position: sticky;
+	top: 0;
+	z-index: 10;
+	padding: 7px 16px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	background: var(--color-main-background);
+	pointer-events: none;
+	border-bottom: 1px solid var(--color-border-dark);
+}
+
+.album-detail__sticky-label {
+	font-size: 13px;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+	color: var(--color-main-text);
+}
+
+.album-detail__sticky-count {
+	font-size: 11px;
+	font-weight: 400;
+	color: var(--color-text-maxcontrast);
+	background: var(--color-background-dark);
+	border-radius: 20px;
+	padding: 1px 7px;
+}
+
+.album-detail__runway {
+	position: relative;
+	width: 100%;
+}
+
+.album-detail__bucket {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	padding: 15px 16px 0;
+}
+
+.album-detail__bucket-loading {
+	display: flex;
+	justify-content: center;
 	padding: 16px;
-	box-sizing: border-box;
+}
+
+.album-detail__bucket-placeholder {
+	background: var(--color-background-dark);
+	border-radius: 8px;
+	opacity: 0.15;
 }
 
 /* Desktop: Buttons direkt sichtbar */
@@ -291,8 +636,8 @@ watch(() => props.id, () => {
 		padding: 8px 8px 6px;
 	}
 
-	.album-detail__scroll {
-		padding: 8px;
+	.album-detail__bucket {
+		padding: 0 8px;
 	}
 
 	.album-detail__actions-desktop {

--- a/src/components/PersonDetailView.vue
+++ b/src/components/PersonDetailView.vue
@@ -40,6 +40,7 @@
 							class="person-detail__layout-btn"
 							:class="{ 'person-detail__layout-btn--active': store.gridLayout === 'grid' }"
 							:title="t('integration_immich', 'Square grid')"
+							:aria-label="t('integration_immich', 'Square grid')"
 							@click="store.setGridLayout('grid')">
 							<ViewGridIcon :size="16" />
 						</button>
@@ -47,6 +48,7 @@
 							class="person-detail__layout-btn"
 							:class="{ 'person-detail__layout-btn--active': store.gridLayout === 'masonry' }"
 							:title="t('integration_immich', 'Masonry grid')"
+							:aria-label="t('integration_immich', 'Masonry grid')"
 							@click="store.setGridLayout('masonry')">
 							<ViewQuiltIcon :size="16" />
 						</button>
@@ -166,7 +168,10 @@ function estimateBucketHeightMasonry(count, assets = null) {
 		for (const asset of assets) {
 			const ratio = (asset.ratio > 0) ? asset.ratio : MASONRY_DEFAULT_RATIO
 			const itemHeight = colWidth / ratio
-			const minIdx = columnHeights.indexOf(Math.min(...columnHeights))
+			let minIdx = 0
+			for (let i = 1; i < columnHeights.length; i++) {
+				if (columnHeights[i] < columnHeights[minIdx]) minIdx = i
+			}
 			columnHeights[minIdx] += itemHeight + GRID_GAP
 		}
 		return HEADER_HEIGHT + Math.max(...columnHeights)
@@ -488,6 +493,11 @@ onBeforeUnmount(() => {
 .person-detail__layout-btn:hover {
 	color: var(--color-main-text);
 	background: var(--color-background-hover);
+}
+
+.person-detail__layout-btn:focus-visible {
+	outline: 2px solid var(--color-primary);
+	outline-offset: 2px;
 }
 
 .person-detail__layout-btn--active {

--- a/src/components/PersonDetailView.vue
+++ b/src/components/PersonDetailView.vue
@@ -30,10 +30,28 @@
 						class="person-detail__avatar"
 						:alt="personName">
 				</div>
-				<!-- Photo count below breadcrumb -->
-				<span class="person-detail__count">
-					{{ t('integration_immich', '{count} photos', { count: totalCount }) }}
-				</span>
+				<!-- Photo count + layout toggle below breadcrumb -->
+				<div class="person-detail__meta-row">
+					<span class="person-detail__count">
+						{{ t('integration_immich', '{count} photos', { count: totalCount }) }}
+					</span>
+					<div class="person-detail__layout-toggle">
+						<button
+							class="person-detail__layout-btn"
+							:class="{ 'person-detail__layout-btn--active': store.gridLayout === 'grid' }"
+							:title="t('integration_immich', 'Square grid')"
+							@click="store.setGridLayout('grid')">
+							<ViewGridIcon :size="16" />
+						</button>
+						<button
+							class="person-detail__layout-btn"
+							:class="{ 'person-detail__layout-btn--active': store.gridLayout === 'masonry' }"
+							:title="t('integration_immich', 'Masonry grid')"
+							@click="store.setGridLayout('masonry')">
+							<ViewQuiltIcon :size="16" />
+						</button>
+					</div>
+				</div>
 			</div>
 
 			<NcEmptyContent v-if="store.personBuckets.length === 0 && !store.loading"
@@ -67,6 +85,7 @@
 						<PhotoGrid v-else-if="store.personBucketAssets[store.personBuckets[index].timeBucket]"
 							:assets="store.personBucketAssets[store.personBuckets[index].timeBucket]"
 							:selectable="true"
+							:layout="store.gridLayout"
 						@click="(_, idx) => openLightboxFromBucket(idx, index)" />
 						<div v-else
 							class="person-detail__bucket-placeholder"
@@ -88,6 +107,8 @@ import { getPersonThumbnailUrl } from '../services/api.js'
 import PhotoGrid from './PhotoGrid.vue'
 import AlertIcon from 'vue-material-design-icons/Alert.vue'
 import AccountIcon from 'vue-material-design-icons/Account.vue'
+import ViewGridIcon from 'vue-material-design-icons/ViewGrid.vue'
+import ViewQuiltIcon from 'vue-material-design-icons/ViewQuilt.vue'
 
 const props = defineProps({
 	id: { type: String, required: true },
@@ -104,6 +125,7 @@ const BUCKET_PADDING_LR = 32 // .person-detail__bucket padding: 15px 16px → 16
 const OVERSCAN = 800
 const MAX_CONCURRENT = 2
 const MAX_LOADED_BUCKETS = 12
+const MASONRY_DEFAULT_RATIO = 1.0
 
 // --- Reactive state ---
 const scrollContainer = ref(null)
@@ -134,8 +156,34 @@ function estimateBucketHeight(count) {
 	return HEADER_HEIGHT + rows * colWidth + (rows - 1) * GRID_GAP
 }
 
+function estimateBucketHeightMasonry(count, assets = null) {
+	const available = Math.max(GRID_MIN_ITEM, containerWidth.value - BUCKET_PADDING_LR)
+	const cols = Math.max(1, Math.floor((available + GRID_GAP) / (GRID_MIN_ITEM + GRID_GAP)))
+	const colWidth = (available - (cols - 1) * GRID_GAP) / cols
+
+	if (assets && assets.length > 0) {
+		const columnHeights = new Array(cols).fill(0)
+		for (const asset of assets) {
+			const ratio = (asset.ratio > 0) ? asset.ratio : MASONRY_DEFAULT_RATIO
+			const itemHeight = colWidth / ratio
+			const minIdx = columnHeights.indexOf(Math.min(...columnHeights))
+			columnHeights[minIdx] += itemHeight + GRID_GAP
+		}
+		return HEADER_HEIGHT + Math.max(...columnHeights)
+	}
+
+	const itemHeight = colWidth / MASONRY_DEFAULT_RATIO
+	const rows = Math.ceil(count / cols)
+	return HEADER_HEIGHT + rows * (itemHeight + GRID_GAP)
+}
+
 const bucketHeights = computed(() =>
-	store.personBuckets.map(b => estimateBucketHeight(b.count)),
+	store.personBuckets.map(b => {
+		if (store.gridLayout === 'masonry') {
+			return estimateBucketHeightMasonry(b.count, store.personBucketAssets[b.timeBucket])
+		}
+		return estimateBucketHeight(b.count)
+	}),
 )
 
 const bucketOffsets = computed(() => {
@@ -333,11 +381,17 @@ onBeforeUnmount(() => {
 	margin-left: auto;
 }
 
+.person-detail__meta-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 2px;
+}
+
 .person-detail__count {
 	font-size: 13px;
 	color: var(--color-text-maxcontrast);
 	padding-left: 4px;
-	margin-top: 2px;
 }
 
 .person-detail__scroll {
@@ -352,7 +406,7 @@ onBeforeUnmount(() => {
 	z-index: 10;
 	padding: 7px 16px;
 	display: flex;
-	align-items: baseline;
+	align-items: center;
 	gap: 8px;
 	background: var(--color-main-background);
 	pointer-events: none;
@@ -408,5 +462,36 @@ onBeforeUnmount(() => {
 	.person-detail__bucket {
 		padding: 0 8px;
 	}
+}
+
+/* ---- Layout toggle (shared style pattern) ---- */
+.person-detail__layout-toggle {
+	margin-left: auto;
+	display: flex;
+	gap: 2px;
+}
+
+.person-detail__layout-btn {
+	all: unset;
+	box-sizing: border-box;
+	width: 28px;
+	height: 28px;
+	border-radius: 6px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	color: var(--color-text-maxcontrast);
+	transition: color 0.15s ease, background 0.15s ease;
+}
+
+.person-detail__layout-btn:hover {
+	color: var(--color-main-text);
+	background: var(--color-background-hover);
+}
+
+.person-detail__layout-btn--active {
+	color: var(--color-primary);
+	background: var(--color-primary-element-light);
 }
 </style>

--- a/src/components/PhotoGrid.vue
+++ b/src/components/PhotoGrid.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="photo-grid">
+	<div class="photo-grid" :class="{ 'photo-grid--masonry': layout === 'masonry' }">
 		<div v-for="(asset, index) in assets"
 			:key="asset.id"
 			class="photo-grid__item"
@@ -11,6 +11,7 @@
 				'photo-grid__item--selected': selectable && store.selectedAssetIds.has(asset.id),
 				'photo-grid__item--selection-mode': selectable && store.isSelectionMode,
 			}"
+			:style="layout === 'masonry' ? { '--item-ratio': String(getItemRatio(asset)) } : {}"
 			@click="handleClick(asset, index, $event)">
 
 			<!-- Skeleton shown until image loads -->
@@ -70,10 +71,28 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	layout: {
+		type: String,
+		default: 'grid', // 'grid' | 'masonry'
+	},
 })
 
 const emit = defineEmits(['click'])
 const store = useImmichStore()
+
+/**
+ * Returns the aspect ratio (width / height) for a given asset.
+ *
+ * Sources tried in order:
+ *  1. asset.ratio  — present in TimeBucketAssetResponseDto (timeline / person buckets)
+ *  2. asset.width / asset.height — present in AssetResponseDto (album detail, single-asset endpoints)
+ *  3. 1.0 — square fallback when no dimension data is available (e.g. map markers)
+ */
+function getItemRatio(asset) {
+	if (asset.ratio > 0) return asset.ratio
+	if (asset.width > 0 && asset.height > 0) return asset.width / asset.height
+	return 1
+}
 
 function handleClick(asset, index, event) {
 	// If the click originated from the checkbox element, let onCheckboxClick handle it
@@ -287,5 +306,36 @@ function formatDate(asset) {
 .photo-grid__checkbox--checked {
 	opacity: 1 !important;
 	transform: scale(1) !important;
+}
+
+/* ===================== Masonry layout ===================== */
+.photo-grid--masonry {
+	display: block;
+	column-width: 180px; /* matches grid minmax(180px, 1fr) */
+	column-gap: 3px;
+}
+
+@media (max-width: 480px) {
+	.photo-grid--masonry {
+		column-count: 2;
+		column-width: auto;
+	}
+}
+
+/*
+ * Masonry items use the actual aspect ratio from the API (width/height),
+ * instead of the forced 1:1 square used in grid mode.
+ * --item-ratio is set as an inline CSS variable per item in the template.
+ */
+.photo-grid--masonry .photo-grid__item {
+	aspect-ratio: var(--item-ratio, 1);
+	break-inside: avoid;
+	margin-bottom: 3px;
+	/* Disable the scale-on-hover transform in masonry to avoid column layout artifacts */
+	transition: none;
+}
+
+.photo-grid--masonry .photo-grid__item:hover {
+	transform: none;
 }
 </style>

--- a/src/components/PlaceDetailView.vue
+++ b/src/components/PlaceDetailView.vue
@@ -4,7 +4,7 @@
 -->
 <template>
 	<div class="place-detail">
-		<NcLoadingIcon v-if="loadingMarkers"
+		<NcLoadingIcon v-if="store.loading && store.placeAssets.length === 0"
 			:size="64"
 			class="place-detail__loading" />
 
@@ -23,12 +23,30 @@
 					<NcBreadcrumb :name="t('integration_immich', 'Explore')" @click="goBack" />
 					<NcBreadcrumb :name="props.value" :title="props.value" />
 				</NcBreadcrumbs>
-				<span class="place-detail__count">
-					{{ t('integration_immich', '{count} photos', { count: filteredAssets.length }) }}
-				</span>
+				<div class="place-detail__meta-row">
+					<span class="place-detail__count">
+						{{ t('integration_immich', '{count} photos', { count: store.placeAssets.length }) }}
+					</span>
+					<div class="place-detail__layout-toggle">
+						<button
+							class="place-detail__layout-btn"
+							:class="{ 'place-detail__layout-btn--active': store.gridLayout === 'grid' }"
+							:title="t('integration_immich', 'Square grid')"
+							@click="store.setGridLayout('grid')">
+							<ViewGridIcon :size="16" />
+						</button>
+						<button
+							class="place-detail__layout-btn"
+							:class="{ 'place-detail__layout-btn--active': store.gridLayout === 'masonry' }"
+							:title="t('integration_immich', 'Masonry grid')"
+							@click="store.setGridLayout('masonry')">
+							<ViewQuiltIcon :size="16" />
+						</button>
+					</div>
+				</div>
 			</div>
 
-			<NcEmptyContent v-if="filteredAssets.length === 0"
+			<NcEmptyContent v-if="store.placeAssets.length === 0 && !store.loading"
 				:name="t('integration_immich', 'No photos')"
 				:description="t('integration_immich', 'No photos found for this location.')">
 				<template #icon>
@@ -38,16 +56,17 @@
 
 			<div v-else class="place-detail__scroll">
 				<PhotoGrid
-					:assets="filteredAssets"
+					:assets="store.placeAssets"
 					:selectable="true"
-				@click="(_, idx) => store.openLightbox(filteredAssets, idx)" />
+					:layout="store.gridLayout"
+				@click="(_, idx) => store.openLightbox(store.placeAssets, idx)" />
 			</div>
 		</template>
 	</div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { NcEmptyContent, NcLoadingIcon, NcBreadcrumbs, NcBreadcrumb } from '@nextcloud/vue'
 import { translate as t } from '@nextcloud/l10n'
@@ -55,6 +74,8 @@ import { useImmichStore } from '../store/immich.js'
 import PhotoGrid from './PhotoGrid.vue'
 import AlertIcon from 'vue-material-design-icons/Alert.vue'
 import MapMarkerIcon from 'vue-material-design-icons/MapMarker.vue'
+import ViewGridIcon from 'vue-material-design-icons/ViewGrid.vue'
+import ViewQuiltIcon from 'vue-material-design-icons/ViewQuilt.vue'
 
 const props = defineProps({
 	field: { type: String, required: true },   // e.g. "exifInfo.city"
@@ -64,33 +85,15 @@ const props = defineProps({
 const store = useImmichStore()
 const router = useRouter()
 
-function fieldToKey(field) {
-	const map = {
-		'exifInfo.city': 'city',
-		'exifInfo.country': 'country',
-		'exifInfo.state': 'state',
-	}
-	return map[field] ?? field.split('.').pop()
+function load() {
+	store.fetchPlaceAssets(props.field, props.value)
 }
 
-const filteredAssets = computed(() => {
-	const key = fieldToKey(props.field)
-	return store.mapMarkers.filter(m => {
-		// Support both flat top-level key (m.city) and nested path (m.exifInfo?.city)
-		if (m[key] !== undefined) return m[key] === props.value
-		const nested = props.field.split('.').reduce((obj, part) => obj?.[part], m)
-		return nested === props.value
-	})
+onMounted(() => {
+	load()
 })
 
-const loadingMarkers = ref(false)
-onMounted(async () => {
-	if (store.mapMarkers.length === 0) {
-		loadingMarkers.value = true
-		await store.fetchMapMarkers()
-		loadingMarkers.value = false
-	}
-})
+watch(() => [props.field, props.value], load)
 
 function goBack() {
 	router.push({ name: 'explore' })
@@ -123,6 +126,43 @@ function goBack() {
 	color: var(--color-text-maxcontrast);
 	padding-left: 4px;
 	margin-top: 2px;
+}
+
+.place-detail__meta-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 2px;
+}
+
+.place-detail__layout-toggle {
+	margin-left: auto;
+	display: flex;
+	gap: 2px;
+}
+
+.place-detail__layout-btn {
+	all: unset;
+	box-sizing: border-box;
+	width: 28px;
+	height: 28px;
+	border-radius: 6px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	color: var(--color-text-maxcontrast);
+	transition: color 0.15s ease, background 0.15s ease;
+}
+
+.place-detail__layout-btn:hover {
+	color: var(--color-main-text);
+	background: var(--color-background-hover);
+}
+
+.place-detail__layout-btn--active {
+	color: var(--color-primary);
+	background: var(--color-primary-element-light);
 }
 
 .place-detail__scroll {

--- a/src/components/PlaceDetailView.vue
+++ b/src/components/PlaceDetailView.vue
@@ -32,6 +32,7 @@
 							class="place-detail__layout-btn"
 							:class="{ 'place-detail__layout-btn--active': store.gridLayout === 'grid' }"
 							:title="t('integration_immich', 'Square grid')"
+							:aria-label="t('integration_immich', 'Square grid')"
 							@click="store.setGridLayout('grid')">
 							<ViewGridIcon :size="16" />
 						</button>
@@ -39,6 +40,7 @@
 							class="place-detail__layout-btn"
 							:class="{ 'place-detail__layout-btn--active': store.gridLayout === 'masonry' }"
 							:title="t('integration_immich', 'Masonry grid')"
+							:aria-label="t('integration_immich', 'Masonry grid')"
 							@click="store.setGridLayout('masonry')">
 							<ViewQuiltIcon :size="16" />
 						</button>
@@ -158,6 +160,11 @@ function goBack() {
 .place-detail__layout-btn:hover {
 	color: var(--color-main-text);
 	background: var(--color-background-hover);
+}
+
+.place-detail__layout-btn:focus-visible {
+	outline: 2px solid var(--color-primary);
+	outline-offset: 2px;
 }
 
 .place-detail__layout-btn--active {

--- a/src/components/TimelineView.vue
+++ b/src/components/TimelineView.vue
@@ -39,6 +39,7 @@
 						class="timeline-view__layout-btn"
 						:class="{ 'timeline-view__layout-btn--active': store.gridLayout === 'grid' }"
 						:title="t('integration_immich', 'Square grid')"
+						:aria-label="t('integration_immich', 'Square grid')"
 						@click="setLayout('grid')">
 						<ViewGridIcon :size="16" />
 					</button>
@@ -46,6 +47,7 @@
 						class="timeline-view__layout-btn"
 						:class="{ 'timeline-view__layout-btn--active': store.gridLayout === 'masonry' }"
 						:title="t('integration_immich', 'Masonry grid')"
+						:aria-label="t('integration_immich', 'Masonry grid')"
 						@click="setLayout('masonry')">
 						<ViewQuiltIcon :size="16" />
 					</button>
@@ -174,7 +176,10 @@ function estimateBucketHeightMasonry(count, assets = null) {
 		for (const asset of assets) {
 			const ratio = (asset.ratio > 0) ? asset.ratio : MASONRY_DEFAULT_RATIO
 			const itemHeight = colWidth / ratio
-			const minIdx = columnHeights.indexOf(Math.min(...columnHeights))
+			let minIdx = 0
+			for (let i = 1; i < columnHeights.length; i++) {
+				if (columnHeights[i] < columnHeights[minIdx]) minIdx = i
+			}
 			columnHeights[minIdx] += itemHeight + GRID_GAP
 		}
 		return BUCKET_PADDING_TOP + Math.max(...columnHeights)
@@ -574,6 +579,11 @@ function scrollToTop() {
 .timeline-view__layout-btn:hover {
 	color: var(--color-main-text);
 	background: var(--color-background-hover);
+}
+
+.timeline-view__layout-btn:focus-visible {
+	outline: 2px solid var(--color-primary);
+	outline-offset: 2px;
 }
 
 .timeline-view__layout-btn--active {

--- a/src/components/TimelineView.vue
+++ b/src/components/TimelineView.vue
@@ -33,6 +33,23 @@
 			<div class="timeline-view__sticky-date">
 				<span class="timeline-view__sticky-label">{{ currentBucketLabel }}</span>
 				<span class="timeline-view__sticky-count">{{ currentBucketCount }}</span>
+				<!-- Layout toggle: square grid vs. masonry -->
+				<div class="timeline-view__layout-toggle">
+					<button
+						class="timeline-view__layout-btn"
+						:class="{ 'timeline-view__layout-btn--active': store.gridLayout === 'grid' }"
+						:title="t('integration_immich', 'Square grid')"
+						@click="setLayout('grid')">
+						<ViewGridIcon :size="16" />
+					</button>
+					<button
+						class="timeline-view__layout-btn"
+						:class="{ 'timeline-view__layout-btn--active': store.gridLayout === 'masonry' }"
+						:title="t('integration_immich', 'Masonry grid')"
+						@click="setLayout('masonry')">
+						<ViewQuiltIcon :size="16" />
+					</button>
+				</div>
 			</div>
 			<!-- Scroll-to-top button -->
 			<Transition name="timeline-fab">
@@ -58,6 +75,7 @@
 					<PhotoGrid v-else-if="assetsCache[buckets[index].timeBucket]"
 						:assets="assetsCache[buckets[index].timeBucket]"
 						:selectable="true"
+						:layout="store.gridLayout"
 					@click="(_, idx) => openLightboxFromBucket(idx, index)" />
 					<div v-else
 						class="timeline-view__bucket-placeholder"
@@ -76,6 +94,8 @@ import { useImmichStore } from '../store/immich.js'
 import PhotoGrid from './PhotoGrid.vue'
 import AlertIcon from 'vue-material-design-icons/Alert.vue'
 import ImageIcon from 'vue-material-design-icons/Image.vue'
+import ViewGridIcon from 'vue-material-design-icons/ViewGrid.vue'
+import ViewQuiltIcon from 'vue-material-design-icons/ViewQuilt.vue'
 
 const props = defineProps({
 	assetType: { type: String, default: null },
@@ -108,6 +128,9 @@ const GRID_GAP = 3
 const BUCKET_PADDING_TOP = 15
 const BUCKET_PADDING_LR = 32 // 16px left + 16px right
 
+// Default assumed aspect ratio for masonry height estimation of unloaded buckets.
+const MASONRY_DEFAULT_RATIO = 1.0
+
 // --- Reactive state ---
 const scrollContainer = ref(null)
 const scrollTop = ref(0)
@@ -120,6 +143,11 @@ const pendingQueue = []
 // AbortController per timeBucket for in-flight requests
 const abortControllers = new Map()
 
+// --- Layout toggle ---
+function setLayout(layout) {
+	store.setGridLayout(layout)
+}
+
 // --- Height estimation ---
 // Derives column count and row height from the actual container width, matching
 // the CSS grid in PhotoGrid.vue (auto-fill, minmax(180px, 1fr), gap: 3px, aspect-ratio:1).
@@ -131,10 +159,43 @@ function estimateBucketHeight(count) {
 	return BUCKET_PADDING_TOP + rows * colWidth + (rows - 1) * GRID_GAP
 }
 
+// Estimates masonry bucket height.
+// When asset data is already loaded, simulates the CSS columns placement using
+// actual aspect ratios for an accurate result. Falls back to MASONRY_DEFAULT_RATIO
+// for unloaded buckets (placeholder height before data arrives).
+function estimateBucketHeightMasonry(count, assets = null) {
+	const available = Math.max(GRID_MIN_ITEM, containerWidth.value - BUCKET_PADDING_LR)
+	const cols = Math.max(1, Math.floor((available + GRID_GAP) / (GRID_MIN_ITEM + GRID_GAP)))
+	const colWidth = (available - (cols - 1) * GRID_GAP) / cols
+
+	if (assets && assets.length > 0) {
+		// Simulate actual masonry column placement for accurate height estimation
+		const columnHeights = new Array(cols).fill(0)
+		for (const asset of assets) {
+			const ratio = (asset.ratio > 0) ? asset.ratio : MASONRY_DEFAULT_RATIO
+			const itemHeight = colWidth / ratio
+			const minIdx = columnHeights.indexOf(Math.min(...columnHeights))
+			columnHeights[minIdx] += itemHeight + GRID_GAP
+		}
+		return BUCKET_PADDING_TOP + Math.max(...columnHeights)
+	}
+
+	// No asset data yet: estimate with default ratio
+	const itemHeight = colWidth / MASONRY_DEFAULT_RATIO
+	const rows = Math.ceil(count / cols)
+	return BUCKET_PADDING_TOP + rows * (itemHeight + GRID_GAP)
+}
+
 // Track actual measured heights (initially estimated)
 const bucketHeights = computed(() => {
-	// containerWidth is read inside estimateBucketHeight, establishing reactivity.
-	return buckets.value.map(b => estimateBucketHeight(b.count))
+	// containerWidth and gridLayout are reactive dependencies, triggering recompute
+	// when the layout is toggled or the viewport is resized.
+	return buckets.value.map(b => {
+		if (store.gridLayout === 'masonry') {
+			return estimateBucketHeightMasonry(b.count, assetsCache.value[b.timeBucket])
+		}
+		return estimateBucketHeight(b.count)
+	})
 })
 
 // Cumulative offsets for each bucket
@@ -481,11 +542,43 @@ function scrollToTop() {
 	z-index: 10;
 	padding: 7px 16px;
 	display: flex;
-	align-items: baseline;
+	align-items: center;
 	gap: 8px;
 	background: var(--color-main-background);
 	pointer-events: none;
 	border-bottom: 1px solid var(--color-border-dark);
+}
+
+/* ---- Layout toggle ---- */
+.timeline-view__layout-toggle {
+	margin-left: auto;
+	pointer-events: auto; /* re-enable clicks, parent has pointer-events: none */
+	display: flex;
+	gap: 2px;
+}
+
+.timeline-view__layout-btn {
+	all: unset;
+	box-sizing: border-box;
+	width: 28px;
+	height: 28px;
+	border-radius: 6px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	color: var(--color-text-maxcontrast);
+	transition: color 0.15s ease, background 0.15s ease;
+}
+
+.timeline-view__layout-btn:hover {
+	color: var(--color-main-text);
+	background: var(--color-background-hover);
+}
+
+.timeline-view__layout-btn--active {
+	color: var(--color-primary);
+	background: var(--color-primary-element-light);
 }
 
 .timeline-view__sticky-label {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -83,6 +83,10 @@ export function getMapMarkers() {
 	return axios.get(`${baseUrl}/map/markers`)
 }
 
+export function searchByLocation(field, value) {
+	return axios.get(`${baseUrl}/search/location`, { params: { field, value } })
+}
+
 export function getExplore() {
 	return axios.get(`${baseUrl}/explore`)
 }

--- a/src/store/immich.js
+++ b/src/store/immich.js
@@ -292,7 +292,9 @@ export const useImmichStore = defineStore('immich', {
 			this.albumBucketAssets = {}
 			try {
 				const response = await getTimeline({ albumId })
-				this.albumBuckets = Array.isArray(response.data) ? response.data : []
+				if (this.currentAlbumId === albumId) {
+					this.albumBuckets = Array.isArray(response.data) ? response.data : []
+				}
 			} catch (e) {
 				const isTimeout = e.code === 'ECONNABORTED' || e.message?.includes('timeout')
 				this.error = isTimeout
@@ -307,7 +309,9 @@ export const useImmichStore = defineStore('immich', {
 			if (this.albumBucketAssets[timeBucket]) return
 			try {
 				const response = await getTimeline({ albumId, timeBucket })
-				this.albumBucketAssets[timeBucket] = Array.isArray(response.data) ? response.data : []
+				if (this.currentAlbumId === albumId) {
+					this.albumBucketAssets[timeBucket] = Array.isArray(response.data) ? response.data : []
+				}
 			} catch (e) {
 				if (e?.name === 'AbortError' || e?.code === 'ERR_CANCELED') return
 				this.error = e.response?.data?.error || e.message

--- a/src/store/immich.js
+++ b/src/store/immich.js
@@ -4,11 +4,12 @@
  */
 import { defineStore } from 'pinia'
 import { translate as t } from '@nextcloud/l10n'
-import { getTimeline, getAlbums, getAlbum, getPeople, getMapMarkers, getExplore } from '../services/api.js'
+import { getTimeline, getAlbums, getAlbum, getPeople, getMapMarkers, searchByLocation, getExplore } from '../services/api.js'
 import { appStorage } from '../services/storage.js'
 
 const BUCKET_CACHE_KEY = 'timeline_buckets'
 const BUCKET_CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+const LAYOUT_STORAGE_KEY = 'grid_layout'
 
 export const useImmichStore = defineStore('immich', {
 	state: () => ({
@@ -30,8 +31,16 @@ export const useImmichStore = defineStore('immich', {
 		currentPersonId: null,
 		personBuckets: [],
 		personBucketAssets: {},
+		// Album detail — lazy-loaded buckets
+		currentAlbumId: null,
+		albumBuckets: [],
+		albumBucketAssets: {},
 		// Map
 		mapMarkers: [],
+		// Place detail — full asset objects (with width/height) from metadata search
+		placeAssets: [],
+		currentPlaceField: null,
+		currentPlaceValue: null,
 		// Explore
 		exploreData: [],
 		// UI
@@ -46,9 +55,18 @@ export const useImmichStore = defineStore('immich', {
 		// Selection
 		selectedAssetIds: new Set(),
 		isSelectionMode: false,
+		// Layout preference ('grid' | 'masonry') — persisted in localStorage
+		gridLayout: appStorage.getItem(LAYOUT_STORAGE_KEY) ?? 'grid',
 	}),
 
 	actions: {
+		// ---- Layout ----
+
+		setGridLayout(layout) {
+			this.gridLayout = layout
+			appStorage.setItem(LAYOUT_STORAGE_KEY, layout)
+		},
+
 		// ---- Timeline ----
 
 		async fetchTimelineBuckets() {
@@ -264,6 +282,42 @@ export const useImmichStore = defineStore('immich', {
 			delete this.personBucketAssets[timeBucket]
 		},
 
+		// ---- Album detail (lazy buckets) ----
+
+		async fetchAlbumBuckets(albumId) {
+			this.loading = true
+			this.error = null
+			this.currentAlbumId = albumId
+			this.albumBuckets = []
+			this.albumBucketAssets = {}
+			try {
+				const response = await getTimeline({ albumId })
+				this.albumBuckets = Array.isArray(response.data) ? response.data : []
+			} catch (e) {
+				const isTimeout = e.code === 'ECONNABORTED' || e.message?.includes('timeout')
+				this.error = isTimeout
+					? t('integration_immich', 'Request timed out — Immich may be slow or unreachable. Check your server connection.')
+					: (e.response?.data?.error || e.message)
+			} finally {
+				this.loading = false
+			}
+		},
+
+		async fetchAlbumBucketAssets(albumId, timeBucket) {
+			if (this.albumBucketAssets[timeBucket]) return
+			try {
+				const response = await getTimeline({ albumId, timeBucket })
+				this.albumBucketAssets[timeBucket] = Array.isArray(response.data) ? response.data : []
+			} catch (e) {
+				if (e?.name === 'AbortError' || e?.code === 'ERR_CANCELED') return
+				this.error = e.response?.data?.error || e.message
+			}
+		},
+
+		unloadAlbumBucketAsset(timeBucket) {
+			delete this.albumBucketAssets[timeBucket]
+		},
+
 		// ---- Map ----
 
 		async fetchMapMarkers() {
@@ -274,6 +328,27 @@ export const useImmichStore = defineStore('immich', {
 				this.mapMarkers = Array.isArray(response.data) ? response.data : []
 			} catch (e) {
 				this.error = e.response?.data?.error || e.message
+			} finally {
+				this.loading = false
+			}
+		},
+
+		// ---- Place detail ----
+
+		async fetchPlaceAssets(field, value) {
+			this.loading = true
+			this.error = null
+			this.currentPlaceField = field
+			this.currentPlaceValue = value
+			this.placeAssets = []
+			try {
+				const response = await searchByLocation(field, value)
+				this.placeAssets = Array.isArray(response.data) ? response.data : []
+			} catch (e) {
+				const isTimeout = e.code === 'ECONNABORTED' || e.message?.includes('timeout')
+				this.error = isTimeout
+					? t('integration_immich', 'Request timed out — Immich may be slow or unreachable. Check your server connection.')
+					: (e.response?.data?.error || e.message)
 			} finally {
 				this.loading = false
 			}
@@ -365,10 +440,18 @@ export const useImmichStore = defineStore('immich', {
 				this.personBucketAssets[bucket] = this.personBucketAssets[bucket].filter(a => a.id !== assetId)
 			}
 
-			// Remove from album assets
+			// Remove from album bucket assets
+			for (const bucket in this.albumBucketAssets) {
+				this.albumBucketAssets[bucket] = this.albumBucketAssets[bucket].filter(a => a.id !== assetId)
+			}
+
+			// Remove from currentAlbum flat assets (used by AssetPicker)
 			if (this.currentAlbum && this.currentAlbum.assets) {
 				this.currentAlbum.assets = this.currentAlbum.assets.filter(a => a.id !== assetId)
 			}
+
+			// Remove from place assets
+			this.placeAssets = this.placeAssets.filter(a => a.id !== assetId)
 
 			// Remove from explore data
 			this.exploreData.forEach(group => {
@@ -437,10 +520,16 @@ export const useImmichStore = defineStore('immich', {
 			for (const key of Object.keys(this.personBucketAssets)) {
 				patchList(this.personBucketAssets[key])
 			}
-			// Album detail
+			// Album bucket detail
+			for (const key of Object.keys(this.albumBucketAssets)) {
+				patchList(this.albumBucketAssets[key])
+			}
+			// Album flat assets (used by AssetPicker)
 			if (this.currentAlbum?.assets) {
 				patchList(this.currentAlbum.assets)
 			}
+			// Place detail
+			patchList(this.placeAssets)
 			// Lightbox assets
 			patchList(this.lightbox.assets)
 		},
@@ -469,10 +558,16 @@ export const useImmichStore = defineStore('immich', {
 			for (const assets of Object.values(state.personBucketAssets)) {
 				for (const a of assets) map[a.id] = a
 			}
-			// Album detail
+			// Album bucket detail
+			for (const assets of Object.values(state.albumBucketAssets)) {
+				for (const a of assets) map[a.id] = a
+			}
+			// Album flat assets (AssetPicker)
 			if (state.currentAlbum?.assets) {
 				for (const a of state.currentAlbum.assets) map[a.id] = a
 			}
+			// Place detail
+			for (const a of state.placeAssets) map[a.id] = a
 			return map
 		},
 	},

--- a/tests/unit/Controller/AssetsControllerTest.php
+++ b/tests/unit/Controller/AssetsControllerTest.php
@@ -150,6 +150,107 @@ class AssetsControllerTest extends TestCase {
 		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
 	}
 
+	// --- searchLocation() ---
+
+	public function testSearchLocationReturns412WhenNotConfigured(): void {
+		$this->immichService->method('isConfigured')->willReturn(false);
+
+		$response = $this->controller->searchLocation();
+
+		$this->assertEquals(Http::STATUS_PRECONDITION_FAILED, $response->getStatus());
+		$this->assertArrayHasKey('error', $response->getData());
+	}
+
+	public function testSearchLocationReturns400WhenFieldMissing(): void {
+		$this->immichService->method('isConfigured')->willReturn(true);
+		$this->request->method('getParam')->willReturnMap([
+			['field', '', ''],
+			['value', '', 'Berlin'],
+		]);
+
+		$response = $this->controller->searchLocation();
+
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertArrayHasKey('error', $response->getData());
+	}
+
+	public function testSearchLocationReturns400WhenValueMissing(): void {
+		$this->immichService->method('isConfigured')->willReturn(true);
+		$this->request->method('getParam')->willReturnMap([
+			['field', '', 'city'],
+			['value', '', ''],
+		]);
+
+		$response = $this->controller->searchLocation();
+
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertArrayHasKey('error', $response->getData());
+	}
+
+	public function testSearchLocationReturns400OnInvalidField(): void {
+		$this->immichService->method('isConfigured')->willReturn(true);
+		$this->request->method('getParam')->willReturnMap([
+			['field', '', 'exifInfo.make'],
+			['value', '', 'Sony'],
+		]);
+
+		$response = $this->controller->searchLocation();
+
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$data = $response->getData();
+		$this->assertArrayHasKey('error', $data);
+		$this->assertEquals('Invalid field', $data['error']);
+	}
+
+	/**
+	 * @dataProvider allowedLocationFieldsProvider
+	 */
+	public function testSearchLocationSucceedsForAllowedFields(string $field): void {
+		$assets = [['id' => 'uuid-1', 'city' => 'Berlin']];
+
+		$this->immichService->method('isConfigured')->willReturn(true);
+		$this->request->method('getParam')->willReturnMap([
+			['field', '', $field],
+			['value', '', 'Berlin'],
+		]);
+		$this->immichService
+			->expects($this->once())
+			->method('searchByLocation')
+			->with($field, 'Berlin')
+			->willReturn($assets);
+
+		$response = $this->controller->searchLocation();
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$this->assertCount(1, $response->getData());
+	}
+
+	public static function allowedLocationFieldsProvider(): array {
+		return [
+			['exifInfo.city'],
+			['exifInfo.country'],
+			['exifInfo.state'],
+			['city'],
+			['country'],
+			['state'],
+		];
+	}
+
+	public function testSearchLocationPropagatesServiceException(): void {
+		$this->immichService->method('isConfigured')->willReturn(true);
+		$this->request->method('getParam')->willReturnMap([
+			['field', '', 'city'],
+			['value', '', 'Berlin'],
+		]);
+		$this->immichService
+			->method('searchByLocation')
+			->willThrowException(new \Exception('Connection failed'));
+
+		$response = $this->controller->searchLocation();
+
+		$this->assertGreaterThanOrEqual(400, $response->getStatus());
+	}
+
 	// --- mapMarkers() ---
 
 	public function testMapMarkersReturns412WhenNotConfigured(): void {


### PR DESCRIPTION
## Summary

Implements masonry grid layout support across all photo views, along with album lazy-bucket loading and a dedicated place/location asset search.

Closes #79

## Changes

### New Features
- **Masonry/grid layout toggle** added to Timeline, Person detail, Album detail, and Place detail views
- **Album lazy-bucket loading** — albums now use the same virtual-scroll + bucket pattern as the timeline and person views (`fetchAlbumBuckets` / `fetchAlbumBucketAssets`)
- **Place/location asset search** — `PlaceDetailView` now fetches full `AssetResponseDto` objects (with `width`/`height`) via Immich's `POST /search/metadata` endpoint instead of filtering `mapMarkers`, enabling correct masonry ratios for place results
- **`getItemRatio()` in `PhotoGrid`** — resolves aspect ratio from `asset.ratio` (timeline buckets), `asset.width` / `asset.height` (album/place assets), or falls back to `1.0`

### Store (`immich.js`)
- `gridLayout` state + `setGridLayout()` action moved into Pinia store (was local `ref` + `appStorage` in `TimelineView`)
- Added `albumBuckets`, `albumBucketAssets`, `placeAssets` state slices
- `removeAssetFromAllCaches` and `patchAssetFavorite` updated to cover new caches

### Security Fix
- `searchLocation` controller now whitelists allowed `field` values (`exifInfo.city`, `exifInfo.country`, `exifInfo.state`, `city`, `country`, `state`) — the previous fallback `$fieldMap[$field] ?? $field` allowed querying arbitrary Immich metadata fields

### Bug Fixes
- `pointer-events: none` restored on `.person-detail__sticky-date` (was accidentally removed)
