### PR TITLE
fix(people): increase face thumbnail size and improve hair visibility

### DIFF
--- a/src/components/PeopleView.vue
+++ b/src/components/PeopleView.vue
@@ -104,7 +104,7 @@ onMounted(() => {
 .people-view__face {
 	width: 120px;
 	height: 120px;
-	border-radius: 12px;
+	border-radius: 8px;
 	overflow: hidden;
 	background: var(--color-background-dark);
 }

--- a/src/components/PeopleView.vue
+++ b/src/components/PeopleView.vue
@@ -102,9 +102,9 @@ onMounted(() => {
 }
 
 .people-view__face {
-	width: 96px;
-	height: 96px;
-	border-radius: 50%;
+	width: 120px;
+	height: 120px;
+	border-radius: 12px;
 	overflow: hidden;
 	background: var(--color-background-dark);
 }
@@ -113,6 +113,7 @@ onMounted(() => {
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
+	object-position: center top;
 }
 
 .people-view__name {
@@ -121,7 +122,7 @@ onMounted(() => {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	max-width: 120px;
+	max-width: 130px;
 	color: var(--color-main-text);
 }
 
@@ -131,12 +132,12 @@ onMounted(() => {
 	}
 
 	.people-view__face {
-		width: 72px;
-		height: 72px;
+		width: 96px;
+		height: 96px;
 	}
 
 	.people-view__name {
-		max-width: 90px;
+		max-width: 100px;
 	}
 }
 </style>

--- a/src/components/PersonDetailView.vue
+++ b/src/components/PersonDetailView.vue
@@ -325,10 +325,11 @@ onBeforeUnmount(() => {
 }
 
 .person-detail__avatar {
-	width: 40px;
-	height: 40px;
-	border-radius: 50%;
+	width: 48px;
+	height: 48px;
+	border-radius: 8px;
 	object-fit: cover;
+	object-position: center top;
 	flex-shrink: 0;
 	margin-left: auto;
 }


### PR DESCRIPTION
## Summary

Fixes #74

The people view showed face thumbnails as small 96px circles. The circular crop was cutting off hair at the top, making it hard to identify people by their haircut.

## Changes

### `PeopleView.vue`
- Increased face image size from **96px to 120px**
- Changed shape from circle (`border-radius: 50%`) to **rounded square** (`border-radius: 12px`) to avoid clipping hair at the top
- Added `object-position: center top` to show more hair/haircut
- Updated mobile breakpoint: 72px to 96px

### `PersonDetailView.vue`
- Increased header avatar from **40px to 48px**
- Same shape and position adjustments for consistency

## Before / After

| Property | Before | After |
|---|---|---|
| Size | 96px | 120px |
| Shape | Circle (`border-radius: 50%`) | Rounded square (`border-radius: 12px`) |
| Image position | `object-position: center` | `object-position: center top` |
| Mobile size | 72px | 96px |
