### PR TITLE
fix: show shared albums and add role-based permissions

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -16,6 +16,7 @@ return [
         // Admin Config
         ['name' => 'config#setConfig', 'url' => '/api/v1/config', 'verb' => 'PUT'],
         ['name' => 'config#getConfig', 'url' => '/api/v1/config', 'verb' => 'GET'],
+        ['name' => 'config#me',        'url' => '/api/v1/me',     'verb' => 'GET'],
 
         // Assets / Timeline
         ['name' => 'assets#timeline',        'url' => '/api/v1/timeline',                    'verb' => 'GET'],

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -142,7 +142,14 @@ OC.L10N.register(
     "{count} asset(s) removed from album": "{count} Asset(s) aus Album entfernt",
     "{succeeded} removed, {failed} failed": "{succeeded} entfernt, {failed} fehlgeschlagen",
     "Error removing from album": "Fehler beim Entfernen aus Album",
-    "Error removing: {msg}": "Fehler beim Entfernen: {msg}"
+    "Error removing: {msg}": "Fehler beim Entfernen: {msg}",
+    "Shared with me": "Mit mir geteilt",
+    "Shared ({role})": "Geteilt ({role})",
+    "Editor": "Bearbeiter",
+    "Viewer": "Betrachter",
+    "_{count} photo_::_{count} photos_": ["{count} Bild","{count} Bilder"],
+    "_{count} photo added to album_::_{count} photos added to album_": ["{count} Bild zum Album hinzugefügt","{count} Bilder zum Album hinzugefügt"],
+    "_{count} photo with location_::_{count} photos with location_": ["{count} Foto mit Standort","{count} Fotos mit Standort"]
   },
   "nplurals=2; plural=(n != 1);"
 );

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -141,7 +141,14 @@
     "{count} asset(s) removed from album": "{count} Asset(s) aus Album entfernt",
     "{succeeded} removed, {failed} failed": "{succeeded} entfernt, {failed} fehlgeschlagen",
     "Error removing from album": "Fehler beim Entfernen aus Album",
-    "Error removing: {msg}": "Fehler beim Entfernen: {msg}"
+    "Error removing: {msg}": "Fehler beim Entfernen: {msg}",
+    "Shared with me": "Mit mir geteilt",
+    "Shared ({role})": "Geteilt ({role})",
+    "Editor": "Bearbeiter",
+    "Viewer": "Betrachter",
+    "_{count} photo_::_{count} photos_": ["{count} Bild", "{count} Bilder"],
+    "_{count} photo added to album_::_{count} photos added to album_": ["{count} Bild zum Album hinzugefügt", "{count} Bilder zum Album hinzugefügt"],
+    "_{count} photo with location_::_{count} photos with location_": ["{count} Foto mit Standort", "{count} Fotos mit Standort"]
   },
   "pluralForm": "nplurals=2; plural=(n != 1);"
 }

--- a/l10n/es-ES.js
+++ b/l10n/es-ES.js
@@ -142,7 +142,14 @@ OC.L10N.register(
     "{count} asset(s) removed from album": "{count} elemento(s) eliminado(s) del álbum",
     "{succeeded} removed, {failed} failed": "{succeeded} eliminado(s), {failed} fallido(s)",
     "Error removing from album": "Error al eliminar del álbum",
-    "Error removing: {msg}": "Error al eliminar: {msg}"
+    "Error removing: {msg}": "Error al eliminar: {msg}",
+    "Shared with me": "Compartido conmigo",
+    "Shared ({role})": "Compartido ({role})",
+    "Editor": "Editor",
+    "Viewer": "Visor",
+    "_{count} photo_::_{count} photos_": ["{count} foto","{count} fotos"],
+    "_{count} photo added to album_::_{count} photos added to album_": ["{count} foto añadida al álbum","{count} fotos añadidas al álbum"],
+    "_{count} photo with location_::_{count} photos with location_": ["{count} foto con ubicación","{count} fotos con ubicación"]
   },
   "nplurals=2; plural=(n != 1);"
 );

--- a/l10n/es-ES.json
+++ b/l10n/es-ES.json
@@ -141,7 +141,14 @@
     "{count} asset(s) removed from album": "{count} elemento(s) eliminado(s) del álbum",
     "{succeeded} removed, {failed} failed": "{succeeded} eliminado(s), {failed} fallido(s)",
     "Error removing from album": "Error al eliminar del álbum",
-    "Error removing: {msg}": "Error al eliminar: {msg}"
+    "Error removing: {msg}": "Error al eliminar: {msg}",
+    "Shared with me": "Compartido conmigo",
+    "Shared ({role})": "Compartido ({role})",
+    "Editor": "Editor",
+    "Viewer": "Visor",
+    "_{count} photo_::_{count} photos_": ["{count} foto", "{count} fotos"],
+    "_{count} photo added to album_::_{count} photos added to album_": ["{count} foto añadida al álbum", "{count} fotos añadidas al álbum"],
+    "_{count} photo with location_::_{count} photos with location_": ["{count} foto con ubicación", "{count} fotos con ubicación"]
   },
   "pluralForm": "nplurals=2; plural=(n != 1);"
 }

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -142,7 +142,14 @@ OC.L10N.register(
     "{count} asset(s) removed from album": "{count} élément(s) supprimé(s) de l'album",
     "{succeeded} removed, {failed} failed": "{succeeded} supprimé(s), {failed} échoué(s)",
     "Error removing from album": "Erreur lors de la suppression de l'album",
-    "Error removing: {msg}": "Erreur lors de la suppression : {msg}"
+    "Error removing: {msg}": "Erreur lors de la suppression : {msg}",
+    "Shared with me": "Partagé avec moi",
+    "Shared ({role})": "Partagé ({role})",
+    "Editor": "Éditeur",
+    "Viewer": "Lecteur",
+    "_{count} photo_::_{count} photos_": ["{count} photo","{count} photos"],
+    "_{count} photo added to album_::_{count} photos added to album_": ["{count} photo ajoutée à l'album","{count} photos ajoutées à l'album"],
+    "_{count} photo with location_::_{count} photos with location_": ["{count} photo avec emplacement","{count} photos avec emplacement"]
   },
   "nplurals=2; plural=(n > 1);"
 );

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -141,7 +141,14 @@
     "{count} asset(s) removed from album": "{count} élément(s) supprimé(s) de l'album",
     "{succeeded} removed, {failed} failed": "{succeeded} supprimé(s), {failed} échoué(s)",
     "Error removing from album": "Erreur lors de la suppression de l'album",
-    "Error removing: {msg}": "Erreur lors de la suppression : {msg}"
+    "Error removing: {msg}": "Erreur lors de la suppression : {msg}",
+    "Shared with me": "Partagé avec moi",
+    "Shared ({role})": "Partagé ({role})",
+    "Editor": "Éditeur",
+    "Viewer": "Lecteur",
+    "_{count} photo_::_{count} photos_": ["{count} photo", "{count} photos"],
+    "_{count} photo added to album_::_{count} photos added to album_": ["{count} photo ajoutée à l'album", "{count} photos ajoutées à l'album"],
+    "_{count} photo with location_::_{count} photos with location_": ["{count} photo avec emplacement", "{count} photos avec emplacement"]
   },
   "pluralForm": "nplurals=2; plural=(n > 1);"
 }

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -142,7 +142,14 @@ OC.L10N.register(
     "{count} asset(s) removed from album": "{count} item(s) verwijderd uit album",
     "{succeeded} removed, {failed} failed": "{succeeded} verwijderd, {failed} mislukt",
     "Error removing from album": "Fout bij verwijderen uit album",
-    "Error removing: {msg}": "Fout bij verwijderen: {msg}"
+    "Error removing: {msg}": "Fout bij verwijderen: {msg}",
+    "Shared with me": "Met mij gedeeld",
+    "Shared ({role})": "Gedeeld ({role})",
+    "Editor": "Bewerker",
+    "Viewer": "Kijker",
+    "_{count} photo_::_{count} photos_": ["{count} foto","{count} foto's"],
+    "_{count} photo added to album_::_{count} photos added to album_": ["{count} foto toegevoegd aan album","{count} foto's toegevoegd aan album"],
+    "_{count} photo with location_::_{count} photos with location_": ["{count} foto met locatie","{count} foto's met locatie"]
   },
   "nplurals=2; plural=(n != 1);"
 );

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -141,7 +141,14 @@
     "{count} asset(s) removed from album": "{count} item(s) verwijderd uit album",
     "{succeeded} removed, {failed} failed": "{succeeded} verwijderd, {failed} mislukt",
     "Error removing from album": "Fout bij verwijderen uit album",
-    "Error removing: {msg}": "Fout bij verwijderen: {msg}"
+    "Error removing: {msg}": "Fout bij verwijderen: {msg}",
+    "Shared with me": "Met mij gedeeld",
+    "Shared ({role})": "Gedeeld ({role})",
+    "Editor": "Bewerker",
+    "Viewer": "Kijker",
+    "_{count} photo_::_{count} photos_": ["{count} foto", "{count} foto's"],
+    "_{count} photo added to album_::_{count} photos added to album_": ["{count} foto toegevoegd aan album", "{count} foto's toegevoegd aan album"],
+    "_{count} photo with location_::_{count} photos with location_": ["{count} foto met locatie", "{count} foto's met locatie"]
   },
   "pluralForm": "nplurals=2; plural=(n != 1);"
 }

--- a/l10n/pt.js
+++ b/l10n/pt.js
@@ -142,7 +142,14 @@ OC.L10N.register(
     "{count} asset(s) removed from album": "{count} item(ns) removido(s) do álbum",
     "{succeeded} removed, {failed} failed": "{succeeded} removido(s), {failed} falha(s)",
     "Error removing from album": "Erro ao remover do álbum",
-    "Error removing: {msg}": "Erro ao remover: {msg}"
+    "Error removing: {msg}": "Erro ao remover: {msg}",
+    "Shared with me": "Compartilhado comigo",
+    "Shared ({role})": "Compartilhado ({role})",
+    "Editor": "Editor",
+    "Viewer": "Visualizador",
+    "_{count} photo_::_{count} photos_": ["{count} foto","{count} fotos"],
+    "_{count} photo added to album_::_{count} photos added to album_": ["{count} foto adicionada ao álbum","{count} fotos adicionadas ao álbum"],
+    "_{count} photo with location_::_{count} photos with location_": ["{count} foto com localização","{count} fotos com localização"]
   },
   "nplurals=2; plural=(n > 1);"
 );

--- a/l10n/pt.json
+++ b/l10n/pt.json
@@ -141,7 +141,14 @@
     "{count} asset(s) removed from album": "{count} item(ns) removido(s) do álbum",
     "{succeeded} removed, {failed} failed": "{succeeded} removido(s), {failed} falha(s)",
     "Error removing from album": "Erro ao remover do álbum",
-    "Error removing: {msg}": "Erro ao remover: {msg}"
+    "Error removing: {msg}": "Erro ao remover: {msg}",
+    "Shared with me": "Compartilhado comigo",
+    "Shared ({role})": "Compartilhado ({role})",
+    "Editor": "Editor",
+    "Viewer": "Visualizador",
+    "_{count} photo_::_{count} photos_": ["{count} foto", "{count} fotos"],
+    "_{count} photo added to album_::_{count} photos added to album_": ["{count} foto adicionada ao álbum", "{count} fotos adicionadas ao álbum"],
+    "_{count} photo with location_::_{count} photos with location_": ["{count} foto com localização", "{count} fotos com localização"]
   },
   "pluralForm": "nplurals=2; plural=(n > 1);"
 }

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -118,7 +118,9 @@ class ConfigController extends Controller {
         }
         try {
             $user = $this->immichService->getMe();
-            return new JSONResponse($user);
+            // The frontend only needs the user id for ownership/permission checks.
+            // Returning the full payload would expose unnecessary user data.
+            return new JSONResponse(['id' => $user['id'] ?? null]);
         } catch (\Exception $e) {
             $this->logger->error('Immich /users/me request failed: ' . $e->getMessage(), [
                 'app' => \OCA\IntegrationImmich\AppInfo\Application::APP_ID,

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -102,4 +102,32 @@ class ConfigController extends Controller {
 
         return new JSONResponse(['success' => true]);
     }
+
+    /**
+     * Returns the Immich user profile of the currently authenticated API-key owner.
+     * The frontend uses this to determine album ownership (show/hide the delete button).
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function me(): JSONResponse {
+        if (!$this->immichService->isConfigured()) {
+            return new JSONResponse(
+                ['error' => 'Immich is not configured'],
+                Http::STATUS_PRECONDITION_FAILED
+            );
+        }
+        try {
+            $user = $this->immichService->getMe();
+            return new JSONResponse($user);
+        } catch (\Exception $e) {
+            $this->logger->error('Immich /users/me request failed: ' . $e->getMessage(), [
+                'app' => \OCA\IntegrationImmich\AppInfo\Application::APP_ID,
+                'exception' => $e,
+            ]);
+            return new JSONResponse(
+                ['error' => 'An internal error occurred'],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }
+    }
 }

--- a/lib/Service/ImmichService.php
+++ b/lib/Service/ImmichService.php
@@ -312,12 +312,41 @@ class ImmichService {
     }
 
     public function getAlbums(string $assetId = ''): array {
-        $options = $assetId !== '' ? ['query' => ['assetId' => $assetId]] : [];
-        return $this->request('GET', '/albums', $options);
+        // When filtering by asset, a single call is sufficient.
+        if ($assetId !== '') {
+            return $this->request('GET', '/albums', ['query' => ['assetId' => $assetId]]);
+        }
+
+        // Fetch albums owned by the user.
+        $owned = $this->request('GET', '/albums', []);
+
+        // Fetch albums shared with the user (owned by someone else).
+        // Immich returns different sets for these two calls — mirroring the
+        // behaviour of the official Immich web client.
+        $shared = $this->request('GET', '/albums', ['query' => ['shared' => 'true']]);
+
+        // Merge and deduplicate by album id so that albums the user both owns
+        // AND has shared with others appear only once.
+        $merged = $owned;
+        $seenIds = array_column($owned, 'id');
+        foreach ($shared as $album) {
+            if (!in_array($album['id'], $seenIds, true)) {
+                $merged[] = $album;
+            }
+        }
+
+        return $merged;
     }
 
     public function getAlbum(string $id): array {
         return $this->request('GET', '/albums/' . $id);
+    }
+
+    /**
+     * Returns the Immich user profile of the currently authenticated API key owner.
+     */
+    public function getMe(): array {
+        return $this->request('GET', '/users/me');
     }
 
     public function createAlbum(string $albumName, array $assetIds = []): array {

--- a/lib/Service/ImmichService.php
+++ b/lib/Service/ImmichService.php
@@ -325,13 +325,15 @@ class ImmichService {
         // behaviour of the official Immich web client.
         $shared = $this->request('GET', '/albums', ['query' => ['shared' => 'true']]);
 
-        // Merge and deduplicate by album id so that albums the user both owns
-        // AND has shared with others appear only once.
+        // Merge and deduplicate by album id using a hash set (associative array)
+        // to avoid O(n*m) cost of in_array() and handle missing 'id' gracefully.
         $merged = $owned;
-        $seenIds = array_column($owned, 'id');
+        $seenIds = array_fill_keys(array_filter(array_column($owned, 'id')), true);
         foreach ($shared as $album) {
-            if (!in_array($album['id'], $seenIds, true)) {
+            $albumId = $album['id'] ?? null;
+            if ($albumId !== null && !isset($seenIds[$albumId])) {
                 $merged[] = $album;
+                $seenIds[$albumId] = true;
             }
         }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -199,11 +199,15 @@ const selectedAllFavorited = computed(() => {
 // True when we are inside an album detail view → album button becomes "remove"
 const isAlbumDetailView = computed(() => route.name === 'album-detail')
 
-// Role of the current user in the currently open album (for album-detail view)
+// Role of the current user in the currently open album (for album-detail view).
+// When the user identity is not yet known (or /me failed) we use album.shared as a
+// heuristic: shared albums are treated as viewer-only; unshared albums are owned.
 const currentAlbumMyRole = computed(() => {
-	if (!store.currentUserId || !store.currentAlbum?.albumUsers) return 'owner'
+	const sharedFallback = store.currentAlbum?.shared ? 'viewer' : 'owner'
+	if (!store.currentUserId || !store.currentAlbum?.albumUsers) return sharedFallback
 	const entry = store.currentAlbum.albumUsers.find(u => u.user?.id === store.currentUserId)
-	return entry?.role ?? 'viewer'
+	if (entry !== undefined) return entry.role
+	return sharedFallback
 })
 const currentAlbumCanEdit = computed(() =>
 	currentAlbumMyRole.value === 'owner' || currentAlbumMyRole.value === 'editor'

--- a/src/App.vue
+++ b/src/App.vue
@@ -200,14 +200,15 @@ const selectedAllFavorited = computed(() => {
 const isAlbumDetailView = computed(() => route.name === 'album-detail')
 
 // Role of the current user in the currently open album (for album-detail view).
-// When the user identity is not yet known (or /me failed) we use album.shared as a
-// heuristic: shared albums are treated as viewer-only; unshared albums are owned.
+// Important: Immich does NOT put the owner into albumUsers – check ownerId first.
 const currentAlbumMyRole = computed(() => {
-	const sharedFallback = store.currentAlbum?.shared ? 'viewer' : 'owner'
-	if (!store.currentUserId || !store.currentAlbum?.albumUsers) return sharedFallback
-	const entry = store.currentAlbum.albumUsers.find(u => u.user?.id === store.currentUserId)
+	if (!store.currentUserId || !store.currentAlbum) return 'viewer'
+	// Owner is never in albumUsers – check ownerId/owner.id directly
+	if (store.currentAlbum.ownerId === store.currentUserId
+		|| store.currentAlbum.owner?.id === store.currentUserId) return 'owner'
+	const entry = store.currentAlbum.albumUsers?.find(u => u.user?.id === store.currentUserId)
 	if (entry !== undefined) return entry.role
-	return sharedFallback
+	return 'viewer'
 })
 const currentAlbumCanEdit = computed(() =>
 	currentAlbumMyRole.value === 'owner' || currentAlbumMyRole.value === 'editor'

--- a/src/App.vue
+++ b/src/App.vue
@@ -64,7 +64,7 @@
 									</template>
 									{{ t('integration_immich', 'Download') }}
 								</NcActionButton>
-								<NcActionButton v-if="isAlbumDetailView"
+								<NcActionButton v-if="isAlbumDetailView && currentAlbumCanEdit"
 									type="error"
 									:disabled="store.selectedAssetIds.size === 0 || removingFromAlbum"
 									@click="removeFromCurrentAlbum">
@@ -73,7 +73,7 @@
 									</template>
 									{{ t('integration_immich', 'Remove from album') }}
 								</NcActionButton>
-								<NcActionButton v-else
+								<NcActionButton v-else-if="!isAlbumDetailView"
 									:disabled="store.selectedAssetIds.size === 0 || addingToAlbum"
 									@click="showAlbumPicker = true">
 									<template #icon>
@@ -152,7 +152,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { NcContent, NcAppContent, NcButton, NcLoadingIcon, NcDialog, NcActions, NcActionButton, NcListItem } from '@nextcloud/vue'
 import { translate as t } from '@nextcloud/l10n'
@@ -199,6 +199,16 @@ const selectedAllFavorited = computed(() => {
 // True when we are inside an album detail view → album button becomes "remove"
 const isAlbumDetailView = computed(() => route.name === 'album-detail')
 
+// Role of the current user in the currently open album (for album-detail view)
+const currentAlbumMyRole = computed(() => {
+	if (!store.currentUserId || !store.currentAlbum?.albumUsers) return 'owner'
+	const entry = store.currentAlbum.albumUsers.find(u => u.user?.id === store.currentUserId)
+	return entry?.role ?? 'viewer'
+})
+const currentAlbumCanEdit = computed(() =>
+	currentAlbumMyRole.value === 'owner' || currentAlbumMyRole.value === 'editor'
+)
+
 const pageTitles = {
 	'timeline': t('integration_immich', 'All media'),
 	'photos': t('integration_immich', 'Photos'),
@@ -224,6 +234,11 @@ watch(() => route.name, () => {
 	if (store.isSelectionMode) {
 		store.clearSelection()
 	}
+})
+
+// Fetch the current Immich user once on startup so album ownership checks work
+onMounted(() => {
+	store.fetchCurrentUser()
 })
 
 async function saveToNextcloud() {

--- a/src/components/AlbumDetailView.vue
+++ b/src/components/AlbumDetailView.vue
@@ -30,13 +30,13 @@
 
 					<!-- Desktop: Buttons direkt sichtbar -->
 					<div class="album-detail__actions-desktop">
-						<NcButton variant="tertiary" @click="startRename">
+						<NcButton v-if="canAdmin" variant="tertiary" @click="startRename">
 							<template #icon>
 								<PencilIcon :size="20" />
 							</template>
 							{{ t('integration_immich', 'Rename') }}
 						</NcButton>
-						<NcButton v-if="store.currentAlbum.assets && store.currentAlbum.assets.length > 0"
+						<NcButton v-if="canEdit && store.currentAlbum.assets && store.currentAlbum.assets.length > 0"
 							variant="secondary"
 							@click="showPicker = true">
 							<template #icon>
@@ -49,13 +49,13 @@
 					<!-- Mobile: NcActions dropdown -->
 					<div class="album-detail__actions-mobile">
 						<NcActions :aria-label="t('integration_immich', 'More actions')">
-							<NcActionButton @click="startRename">
+							<NcActionButton v-if="canAdmin" @click="startRename">
 								<template #icon>
 									<PencilIcon :size="20" />
 								</template>
 								{{ t('integration_immich', 'Rename') }}
 							</NcActionButton>
-							<NcActionButton v-if="totalCount > 0"
+							<NcActionButton v-if="canEdit && totalCount > 0"
 								@click="showPicker = true">
 								<template #icon>
 									<ImagePlusIcon :size="20" />
@@ -68,7 +68,7 @@
 				<!-- Photo count + layout toggle below breadcrumb -->
 				<div class="album-detail__meta-row">
 					<span class="album-detail__count">
-						{{ t('integration_immich', '{count} photos', { count: totalCount }) }}
+						{{ n('integration_immich', '{count} photo', '{count} photos', totalCount, { count: totalCount }) }}
 					</span>
 					<div class="album-detail__layout-toggle">
 						<button
@@ -125,7 +125,7 @@
 					<ImageIcon :size="64" />
 				</template>
 				<template #action>
-					<NcButton variant="primary" @click="showPicker = true">
+					<NcButton v-if="canEdit" variant="primary" @click="showPicker = true">
 						<template #icon>
 							<ImagePlusIcon :size="20" />
 						</template>
@@ -179,7 +179,7 @@
 import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { NcButton, NcEmptyContent, NcLoadingIcon, NcDialog, NcTextField, NcActions, NcActionButton, NcBreadcrumbs, NcBreadcrumb } from '@nextcloud/vue'
-import { translate as t } from '@nextcloud/l10n'
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { useImmichStore } from '../store/immich.js'
 import { addAssetsToAlbum as apiAddAssetsToAlbum, renameAlbum as apiRenameAlbum } from '../services/api.js'
@@ -207,6 +207,27 @@ const addingAssets = ref(false)
 const showRenameDialog = ref(false)
 const renameValue = ref('')
 const renaming = ref(false)
+
+/**
+ * The current Immich user's role in this album.
+ * We find the entry whose user.id matches the logged-in user.
+ * Fallback when the user is not in albumUsers (old Immich / unshared album):
+ * unshared albums are always owned by the current user, shared ones fall back
+ * to 'viewer' to err on the side of restricting write access.
+ * Falls back to 'owner' when currentUserId is not yet known so buttons remain
+ * visible until the check resolves.
+ */
+const myRole = computed(() => {
+	if (!store.currentUserId || !store.currentAlbum?.albumUsers) return 'owner'
+	const entry = store.currentAlbum.albumUsers.find(u => u.user?.id === store.currentUserId)
+	if (entry !== undefined) return entry.role
+	// User not found in albumUsers (older Immich API or empty array):
+	// unshared albums belong to the current user → 'owner'.
+	return store.currentAlbum.shared ? 'viewer' : 'owner'
+})
+
+const canEdit  = computed(() => myRole.value === 'owner' || myRole.value === 'editor')
+const canAdmin = computed(() => myRole.value === 'owner')
 
 // --- Constants (same pattern as PersonDetailView) ---
 const HEADER_HEIGHT = 40
@@ -438,7 +459,7 @@ async function addAssetsToAlbum(assetIds) {
 		const failed = results.length - succeeded
 		showPicker.value = false
 		if (failed === 0) {
-			showSuccess(t('integration_immich', '{count} photos added to album', { count: succeeded }))
+			showSuccess(n('integration_immich', '{count} photo added to album', '{count} photos added to album', succeeded, { count: succeeded }))
 		} else if (succeeded > 0) {
 			showError(t('integration_immich', '{succeeded} added, {failed} failed', { succeeded, failed }))
 		} else {

--- a/src/components/AlbumDetailView.vue
+++ b/src/components/AlbumDetailView.vue
@@ -210,20 +210,18 @@ const renaming = ref(false)
 
 /**
  * The current Immich user's role in this album.
- * We find the entry whose user.id matches the logged-in user.
- * Fallback uses album.shared as a heuristic: shared albums → viewer,
- * unshared → owner.  This also covers older Immich versions where albumUsers
- * may be empty, and the case where /users/me has not yet resolved.
+ * Important: Immich does NOT put the owner into albumUsers – that array only
+ * contains users the album was shared WITH. The owner is identified via
+ * album.ownerId / album.owner.id.
  */
 const myRole = computed(() => {
-	// Use album.shared as a heuristic when user identity is not yet resolved:
-	// shared albums → viewer, unshared → owner. This is also the final fallback
-	// when the user is not found in albumUsers (older Immich API / empty array).
-	const sharedFallback = store.currentAlbum?.shared ? 'viewer' : 'owner'
-	if (!store.currentUserId || !store.currentAlbum?.albumUsers) return sharedFallback
-	const entry = store.currentAlbum.albumUsers.find(u => u.user?.id === store.currentUserId)
+	if (!store.currentUserId || !store.currentAlbum) return 'viewer'
+	// Owner is never in albumUsers – check ownerId/owner.id directly
+	if (store.currentAlbum.ownerId === store.currentUserId
+		|| store.currentAlbum.owner?.id === store.currentUserId) return 'owner'
+	const entry = store.currentAlbum.albumUsers?.find(u => u.user?.id === store.currentUserId)
 	if (entry !== undefined) return entry.role
-	return sharedFallback
+	return 'viewer'
 })
 
 const canEdit  = computed(() => myRole.value === 'owner' || myRole.value === 'editor')

--- a/src/components/AlbumDetailView.vue
+++ b/src/components/AlbumDetailView.vue
@@ -211,19 +211,19 @@ const renaming = ref(false)
 /**
  * The current Immich user's role in this album.
  * We find the entry whose user.id matches the logged-in user.
- * Fallback when the user is not in albumUsers (old Immich / unshared album):
- * unshared albums are always owned by the current user, shared ones fall back
- * to 'viewer' to err on the side of restricting write access.
- * Falls back to 'owner' when currentUserId is not yet known so buttons remain
- * visible until the check resolves.
+ * Fallback uses album.shared as a heuristic: shared albums → viewer,
+ * unshared → owner.  This also covers older Immich versions where albumUsers
+ * may be empty, and the case where /users/me has not yet resolved.
  */
 const myRole = computed(() => {
-	if (!store.currentUserId || !store.currentAlbum?.albumUsers) return 'owner'
+	// Use album.shared as a heuristic when user identity is not yet resolved:
+	// shared albums → viewer, unshared → owner. This is also the final fallback
+	// when the user is not found in albumUsers (older Immich API / empty array).
+	const sharedFallback = store.currentAlbum?.shared ? 'viewer' : 'owner'
+	if (!store.currentUserId || !store.currentAlbum?.albumUsers) return sharedFallback
 	const entry = store.currentAlbum.albumUsers.find(u => u.user?.id === store.currentUserId)
 	if (entry !== undefined) return entry.role
-	// User not found in albumUsers (older Immich API or empty array):
-	// unshared albums belong to the current user → 'owner'.
-	return store.currentAlbum.shared ? 'viewer' : 'owner'
+	return sharedFallback
 })
 
 const canEdit  = computed(() => myRole.value === 'owner' || myRole.value === 'editor')

--- a/src/components/AlbumsView.vue
+++ b/src/components/AlbumsView.vue
@@ -169,12 +169,13 @@ const deleting = ref(false)
  * given album. We search the albumUsers array for an entry matching the current
  * user and check their role.
  * Fallback: if the user cannot be found in albumUsers (older Immich versions or
- * empty array), we use album.shared as a hint – unshared albums always belong
- * to the current user.
- * Falls back to true when the user id is not yet known so the button stays visible.
+ * empty array), or if currentUserId is not yet known, we use album.shared as a
+ * heuristic – unshared albums always belong to the current user.
  */
 function isOwnedByMe(album) {
-	if (!store.currentUserId) return true
+	// When user identity is unknown, use album.shared as a safe heuristic:
+	// shared albums are not owned by the current user; unshared ones are.
+	if (!store.currentUserId) return !album.shared
 	const myEntry = album.albumUsers?.find(u => u.user?.id === store.currentUserId)
 	if (myEntry !== undefined) return myEntry.role === 'owner'
 	// User not found in albumUsers (empty array or old Immich API):

--- a/src/components/AlbumsView.vue
+++ b/src/components/AlbumsView.vue
@@ -166,21 +166,19 @@ const deleting = ref(false)
 
 /**
  * Returns true if the currently authenticated Immich user is the owner of the
- * given album. We search the albumUsers array for an entry matching the current
- * user and check their role.
- * Fallback: if the user cannot be found in albumUsers (older Immich versions or
- * empty array), or if currentUserId is not yet known, we use album.shared as a
- * heuristic – unshared albums always belong to the current user.
+ * given album.
+ * Important: Immich does NOT put the owner into albumUsers – that array only
+ * contains users the album was shared WITH. The owner is identified via
+ * album.ownerId / album.owner.id.
  */
 function isOwnedByMe(album) {
-	// When user identity is unknown, use album.shared as a safe heuristic:
-	// shared albums are not owned by the current user; unshared ones are.
 	if (!store.currentUserId) return !album.shared
+	// Check ownerId directly – the owner is never in albumUsers
+	if (album.ownerId === store.currentUserId || album.owner?.id === store.currentUserId) return true
+	// Fallback: check albumUsers in case API behaviour ever changes
 	const myEntry = album.albumUsers?.find(u => u.user?.id === store.currentUserId)
 	if (myEntry !== undefined) return myEntry.role === 'owner'
-	// User not found in albumUsers (empty array or old Immich API):
-	// unshared albums are always owned by the current user.
-	return !album.shared
+	return false
 }
 
 /**
@@ -188,8 +186,10 @@ function isOwnedByMe(album) {
  */
 function myRoleIn(album) {
 	if (!store.currentUserId) return null
+	// Owner is never in albumUsers – return null (no shared-role badge for own albums)
+	if (album.ownerId === store.currentUserId || album.owner?.id === store.currentUserId) return null
 	const entry = album.albumUsers?.find(u => u.user?.id === store.currentUserId)
-	if (!entry || entry.role === 'owner') return null
+	if (!entry) return null
 	return entry.role
 }
 

--- a/src/components/AlbumsView.vue
+++ b/src/components/AlbumsView.vue
@@ -54,11 +54,17 @@
 						<h3 class="albums-view__name">
 							{{ album.albumName }}
 						</h3>
-						<span class="albums-view__count">
-							{{ t('integration_immich', '{count} photos', { count: album.assetCount || 0 }) }}
-						</span>
+						<div class="albums-view__meta">
+							<span class="albums-view__count">
+								{{ n('integration_immich', '{count} photo', '{count} photos', album.assetCount || 0, { count: album.assetCount || 0 }) }}
+							</span>
+							<span v-if="myRoleIn(album)" class="albums-view__count">
+								{{ t('integration_immich', 'Shared ({role})', { role: roleLabels[myRoleIn(album)] ?? myRoleIn(album) }) }}
+							</span>
+						</div>
 					</div>
-					<button class="albums-view__delete-btn"
+					<button v-if="isOwnedByMe(album)"
+						class="albums-view__delete-btn"
 						:title="t('integration_immich', 'Delete album')"
 						@click.stop="confirmDelete(album)">
 						<TrashIcon :size="18" />
@@ -137,7 +143,7 @@
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { NcEmptyContent, NcLoadingIcon, NcButton, NcDialog, NcTextField } from '@nextcloud/vue'
-import { translate as t } from '@nextcloud/l10n'
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { useImmichStore } from '../store/immich.js'
 import { getAlbumThumbnailUrl, createAlbum as apiCreateAlbum, deleteAlbum as apiDeleteAlbum } from '../services/api.js'
@@ -157,6 +163,39 @@ const newAlbumName = ref('')
 const creating = ref(false)
 const albumToDelete = ref(null)
 const deleting = ref(false)
+
+/**
+ * Returns true if the currently authenticated Immich user is the owner of the
+ * given album. We search the albumUsers array for an entry matching the current
+ * user and check their role.
+ * Fallback: if the user cannot be found in albumUsers (older Immich versions or
+ * empty array), we use album.shared as a hint – unshared albums always belong
+ * to the current user.
+ * Falls back to true when the user id is not yet known so the button stays visible.
+ */
+function isOwnedByMe(album) {
+	if (!store.currentUserId) return true
+	const myEntry = album.albumUsers?.find(u => u.user?.id === store.currentUserId)
+	if (myEntry !== undefined) return myEntry.role === 'owner'
+	// User not found in albumUsers (empty array or old Immich API):
+	// unshared albums are always owned by the current user.
+	return !album.shared
+}
+
+/**
+ * Returns the current user's role in a shared album, or null for own albums.
+ */
+function myRoleIn(album) {
+	if (!store.currentUserId) return null
+	const entry = album.albumUsers?.find(u => u.user?.id === store.currentUserId)
+	if (!entry || entry.role === 'owner') return null
+	return entry.role
+}
+
+const roleLabels = {
+	editor: t('integration_immich', 'Editor'),
+	viewer: t('integration_immich', 'Viewer'),
+}
 
 function openAlbum(id) {
 	router.push({ name: 'album-detail', params: { id } })
@@ -314,9 +353,19 @@ onMounted(() => {
 	text-overflow: ellipsis;
 }
 
+.albums-view__meta {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 8px;
+}
+
 .albums-view__count {
 	font-size: 13px;
 	color: var(--color-text-maxcontrast);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .albums-view__dialog-body {

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -35,7 +35,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
-import { translate as t } from '@nextcloud/l10n'
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import { useImmichStore } from '../store/immich.js'
 import { getThumbnailUrl } from '../services/api.js'
 import AlertIcon from 'vue-material-design-icons/Alert.vue'
@@ -75,7 +75,7 @@ const infoText = computed(() => {
 			{ total, shown },
 		)
 	}
-	return t('integration_immich', '{count} photos with location', { count: total })
+	return n('integration_immich', '{count} photo with location', '{count} photos with location', total, { count: total })
 })
 
 async function initMap() {

--- a/src/components/PersonDetailView.vue
+++ b/src/components/PersonDetailView.vue
@@ -33,7 +33,7 @@
 				<!-- Photo count + layout toggle below breadcrumb -->
 				<div class="person-detail__meta-row">
 					<span class="person-detail__count">
-						{{ t('integration_immich', '{count} photos', { count: totalCount }) }}
+						{{ n('integration_immich', '{count} photo', '{count} photos', totalCount, { count: totalCount }) }}
 					</span>
 					<div class="person-detail__layout-toggle">
 						<button
@@ -103,7 +103,7 @@
 import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { NcEmptyContent, NcLoadingIcon, NcBreadcrumbs, NcBreadcrumb } from '@nextcloud/vue'
-import { translate as t } from '@nextcloud/l10n'
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import { useImmichStore } from '../store/immich.js'
 import { getPersonThumbnailUrl } from '../services/api.js'
 import PhotoGrid from './PhotoGrid.vue'

--- a/src/components/PlaceDetailView.vue
+++ b/src/components/PlaceDetailView.vue
@@ -25,7 +25,7 @@
 				</NcBreadcrumbs>
 				<div class="place-detail__meta-row">
 					<span class="place-detail__count">
-						{{ t('integration_immich', '{count} photos', { count: store.placeAssets.length }) }}
+						{{ n('integration_immich', '{count} photo', '{count} photos', store.placeAssets.length, { count: store.placeAssets.length }) }}
 					</span>
 					<div class="place-detail__layout-toggle">
 						<button
@@ -71,7 +71,7 @@
 import { onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { NcEmptyContent, NcLoadingIcon, NcBreadcrumbs, NcBreadcrumb } from '@nextcloud/vue'
-import { translate as t } from '@nextcloud/l10n'
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import { useImmichStore } from '../store/immich.js'
 import PhotoGrid from './PhotoGrid.vue'
 import AlertIcon from 'vue-material-design-icons/Alert.vue'

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -15,6 +15,10 @@ export function getAlbums(params = {}) {
 	return axios.get(`${baseUrl}/albums`, { params })
 }
 
+export function getMe() {
+	return axios.get(`${baseUrl}/me`)
+}
+
 export function getAlbum(id) {
 	return axios.get(`${baseUrl}/albums/${id}/show`)
 }

--- a/src/store/immich.js
+++ b/src/store/immich.js
@@ -4,7 +4,7 @@
  */
 import { defineStore } from 'pinia'
 import { translate as t } from '@nextcloud/l10n'
-import { getTimeline, getAlbums, getAlbum, getPeople, getMapMarkers, searchByLocation, getExplore } from '../services/api.js'
+import { getTimeline, getAlbums, getAlbum, getPeople, getMapMarkers, searchByLocation, getExplore, getMe } from '../services/api.js'
 import { appStorage } from '../services/storage.js'
 
 const BUCKET_CACHE_KEY = 'timeline_buckets'
@@ -57,6 +57,8 @@ export const useImmichStore = defineStore('immich', {
 		isSelectionMode: false,
 		// Layout preference ('grid' | 'masonry') — persisted in localStorage
 		gridLayout: appStorage.getItem(LAYOUT_STORAGE_KEY) ?? 'grid',
+		// Current Immich user — used to determine album ownership
+		currentUserId: null,
 	}),
 
 	actions: {
@@ -227,6 +229,18 @@ export const useImmichStore = defineStore('immich', {
 				this.error = e.response?.data?.error || e.message
 			} finally {
 				this.loading = false
+			}
+		},
+
+		// ---- Current Immich user ----
+
+		async fetchCurrentUser() {
+			try {
+				const response = await getMe()
+				this.currentUserId = response.data?.id ?? null
+			} catch {
+				// Non-fatal — album ownership checks will simply not work
+				this.currentUserId = null
 			}
 		},
 


### PR DESCRIPTION
﻿## Summary

Fixes #20

Shared Immich albums (where the current user has **editor** or **viewer** role) were not visible in the Nextcloud integration. Only albums **owned** by the logged-in user were shown.

---

## Root Cause

`ImmichService::getAlbums()` only called `GET /albums`, which returns owned albums only. The Immich API requires a separate call with `?shared=true` to get albums shared with the current user.

---

## Changes

### Backend (lib/)

| File | Change |
|---|---|
| `ImmichService.php` | `getAlbums()` now makes two API calls (owned + `?shared=true`) and merges/deduplicates by ID. New `getMe()` method calls `GET /users/me`. |
| `ConfigController.php` | New `me()` action exposing `GET /api/v1/me`. |
| `appinfo/routes.php` | Register the new `/api/v1/me` route. |

### Frontend (src/)

| File | Change |
|---|---|
| `services/api.js` | Add `getMe()` helper. |
| `store/immich.js` | Add `currentUserId` state and `fetchCurrentUser()` action. |
| `App.vue` | Call `fetchCurrentUser()` on mount; compute role; hide Remove from album button for viewer role. |
| `AlbumsView.vue` | Role-aware Delete button (owner only); shared-role badge next to photo count; fix ownership detection. |
| `AlbumDetailView.vue` | Rename button (owner only); Add photos buttons (owner + editor); same ownership fix. |
| `PersonDetailView.vue` | Singular/plural fix for photo count. |
| `PlaceDetailView.vue` | Singular/plural fix for photo count. |
| `MapView.vue` | Singular/plural fix for photo count. |

### Role permission matrix

| Action | Owner | Editor | Viewer |
|---|:---:|:---:|:---:|
| View album | yes | yes | yes |
| Add photos | yes | yes | no |
| Remove photos from album | yes | yes | no |
| Rename album | yes | no | no |
| Delete album | yes | no | no |

### Translations (de, fr, nl, es-ES, pt)

- Added keys: Shared with me, Shared ({role}), Editor, Viewer
- Added plural forms for all photo-count strings

### Singular/plural fix

Replaced `t()` with `n()` for all photo-count strings so **1 Foto** is shown correctly instead of **1 Fotos**.

---

## Testing

- Install the built `integration_immich-1.2.0.tar.gz`
- Log in as a user who has been **invited** to another user's album (editor or viewer role)
- Verify the shared album appears in the Albums view
- Verify role badges are shown for editor/viewer albums
- Verify the Delete button is hidden for non-owner albums
- Verify the Rename button is hidden for editor/viewer albums
- Verify Add photos / Remove from album buttons are hidden for viewer albums
- Verify singular: album with exactly 1 photo shows 1 Foto not 1 Fotos