### PR TITLE
fix: Immich v2/v3 dual-compat and upload HTTP error handling

### DIFF
--- a/lib/Controller/AlbumsController.php
+++ b/lib/Controller/AlbumsController.php
@@ -220,6 +220,9 @@ class AlbumsController extends Controller {
             $album = $this->immichService->getAlbum($id);
             $thumbnailAssetId = $album['albumThumbnailAssetId'] ?? null;
 
+            // Immich v3 removed the `assets` array from AlbumResponseDto,
+            // so the fallback below only works on v2. On v3 the primary
+            // albumThumbnailAssetId field is always set when an album is non-empty.
             if (!$thumbnailAssetId && !empty($album['assets'])) {
                 $thumbnailAssetId = $album['assets'][0]['id'];
             }

--- a/lib/Service/ImmichService.php
+++ b/lib/Service/ImmichService.php
@@ -550,20 +550,30 @@ class ImmichService {
             ['name' => 'deviceId',      'contents' => 'nextcloud-integration'],
         ];
 
-        $response = $client->post($url, [
-            'headers' => [
-                'x-api-key' => $this->getApiKey(),
-                'Accept'    => 'application/json',
-            ],
-            'multipart'   => $multipart,
-            'http_errors' => false,
-            'timeout'     => 60,
-        ]);
+        try {
+            $response = $client->post($url, [
+                'headers' => [
+                    'x-api-key' => $this->getApiKey(),
+                    'Accept'    => 'application/json',
+                ],
+                'multipart'   => $multipart,
+                'http_errors' => false,
+                'timeout'     => 60,
+            ]);
+        } catch (\Exception $e) {
+            $this->logger->error('Immich upload transport error: ' . $e->getMessage(), [
+                'app'       => Application::APP_ID,
+                'exception' => $e,
+            ]);
+            throw $e;
+        }
 
         $statusCode = $response->getStatusCode();
         if ($statusCode < 200 || $statusCode >= 300) {
+            $body = (string) $response->getBody();
             $this->logger->error('Immich upload returned HTTP ' . $statusCode, [
-                'app' => Application::APP_ID,
+                'app'          => Application::APP_ID,
+                'responseBody' => $body,
             ]);
             throw new \RuntimeException('Immich upload failed: HTTP ' . $statusCode);
         }

--- a/lib/Service/ImmichService.php
+++ b/lib/Service/ImmichService.php
@@ -318,12 +318,16 @@ class ImmichService {
         }
 
         // Fetch albums owned by the user.
-        $owned = $this->request('GET', '/albums', []);
+        // v3 added `isOwned` as a dedicated boolean filter; v2 had `shared`/`isShared`.
+        // Sending all three params is safe: each version reads what it knows and ignores the rest.
+        //   v2: reads `shared=false` to get owned-only albums
+        //   v3: reads `isOwned=true`  to get owned-only albums
+        $owned = $this->request('GET', '/albums', ['query' => ['shared' => 'false', 'isOwned' => 'true']]);
 
         // Fetch albums shared with the user (owned by someone else).
-        // Immich returns different sets for these two calls — mirroring the
-        // behaviour of the official Immich web client.
-        $shared = $this->request('GET', '/albums', ['query' => ['shared' => 'true']]);
+        //   v2 reads `shared=true`   and silently ignores `isShared`
+        //   v3 reads `isShared=true` and silently ignores `shared`
+        $shared = $this->request('GET', '/albums', ['query' => ['shared' => 'true', 'isShared' => 'true']]);
 
         // Merge and deduplicate by album id using a hash set (associative array)
         // to avoid O(n*m) cost of in_array() and handle missing 'id' gracefully.
@@ -455,6 +459,11 @@ class ImmichService {
             $key         => $value,
             'isArchived' => false,
             'size'       => 1000,
+            // v3 changed the default for omitted `visibility` from 'timeline' to 'all'.
+            // Explicitly set 'timeline' here so archived/locked assets are excluded on both
+            // v2 and v3. v2 ignores unknown POST-body fields (Zod strips them silently),
+            // so sending this on v2 is safe — no version detection needed.
+            'visibility' => 'timeline',
         ];
 
         $result = $this->request('POST', '/search/metadata', ['body' => $body]);
@@ -464,8 +473,13 @@ class ImmichService {
     // ---- Explore ----
 
     public function getExplore(): array {
-        // Immich v2.x does not expose /explore.
-        // Build explore sections by grouping map markers by city and country.
+        // GET /map/markers is stable in both v2 and v3 (history: added v1, stable v2).
+        // Response shape: [{id, lat, lon, city, state, country}, …] – unchanged in v3.
+        //
+        // GET /search/explore was considered but only returns `exifInfo.city` and
+        // `createdAt` sections. The `createdAt` items are not geographic and break
+        // the place-detail routing in ExploreView.vue, so we keep the map-markers
+        // approach which provides proper city + country sections.
         try {
             $markers = $this->request('GET', '/map/markers', [
                 'query' => ['isArchived' => 'false'],
@@ -475,16 +489,17 @@ class ImmichService {
                 return [];
             }
 
-            $cities = [];
+            $cities    = [];
             $countries = [];
 
             foreach ($markers as $marker) {
-                $id = $marker['id'] ?? null;
+                $id      = $marker['id']      ?? null;
+                $city    = $marker['city']    ?? null;
+                $country = $marker['country'] ?? null;
+
                 if (!$id) {
                     continue;
                 }
-                $city = $marker['city'] ?? null;
-                $country = $marker['country'] ?? null;
 
                 if ($city !== null && $city !== '' && !isset($cities[$city])) {
                     $cities[$city] = ['value' => $city, 'data' => ['id' => $id]];
@@ -504,7 +519,7 @@ class ImmichService {
 
             return $result;
         } catch (\Exception $e) {
-            $this->logger->warning('Explore via map markers failed: ' . $e->getMessage(), [
+            $this->logger->warning('Immich /map/markers request failed: ' . $e->getMessage(), [
                 'app' => Application::APP_ID,
             ]);
             return [];
@@ -520,23 +535,38 @@ class ImmichService {
         string $createdAt,
         string $modifiedAt,
     ): array {
-        $deviceAssetId = $fileName . '-' . bin2hex(random_bytes(8));
         $client = $this->clientService->newClient();
         $url = $this->getServerUrl() . '/api/assets';
+
+        $multipart = [
+            ['name' => 'assetData', 'contents' => $fileContent, 'filename' => $fileName, 'headers' => ['Content-Type' => $mimeType]],
+            ['name' => 'fileCreatedAt', 'contents' => $createdAt],
+            ['name' => 'fileModifiedAt', 'contents' => $modifiedAt],
+            // v2 required deviceAssetId and deviceId; v3 removed them from its DTO but
+            // uses Zod without `.strict()`, so unknown multipart fields are silently
+            // stripped rather than rejected. Sending them is therefore safe on v3 too —
+            // no version detection needed.
+            ['name' => 'deviceAssetId', 'contents' => $fileName . '-' . bin2hex(random_bytes(8))],
+            ['name' => 'deviceId',      'contents' => 'nextcloud-integration'],
+        ];
 
         $response = $client->post($url, [
             'headers' => [
                 'x-api-key' => $this->getApiKey(),
-                'Accept' => 'application/json',
+                'Accept'    => 'application/json',
             ],
-            'multipart' => [
-                ['name' => 'assetData', 'contents' => $fileContent, 'filename' => $fileName, 'headers' => ['Content-Type' => $mimeType]],
-                ['name' => 'deviceAssetId', 'contents' => $deviceAssetId],
-                ['name' => 'deviceId', 'contents' => 'nextcloud-integration'],
-                ['name' => 'fileCreatedAt', 'contents' => $createdAt],
-                ['name' => 'fileModifiedAt', 'contents' => $modifiedAt],
-            ],
+            'multipart'   => $multipart,
+            'http_errors' => false,
+            'timeout'     => 60,
         ]);
+
+        $statusCode = $response->getStatusCode();
+        if ($statusCode < 200 || $statusCode >= 300) {
+            $this->logger->error('Immich upload returned HTTP ' . $statusCode, [
+                'app' => Application::APP_ID,
+            ]);
+            throw new \RuntimeException('Immich upload failed: HTTP ' . $statusCode);
+        }
 
         $decoded = json_decode($response->getBody(), true);
         return is_array($decoded) ? $decoded : ['status' => 'unknown', 'raw' => (string)$response->getBody()];

--- a/src/App.vue
+++ b/src/App.vue
@@ -200,12 +200,14 @@ const selectedAllFavorited = computed(() => {
 const isAlbumDetailView = computed(() => route.name === 'album-detail')
 
 // Role of the current user in the currently open album (for album-detail view).
-// Important: Immich does NOT put the owner into albumUsers – check ownerId first.
+// v2: owner is identified via ownerId / owner.id (never in albumUsers).
+// v3: ownerId/owner were removed; the owner is now in albumUsers with role 'owner'.
 const currentAlbumMyRole = computed(() => {
 	if (!store.currentUserId || !store.currentAlbum) return 'viewer'
-	// Owner is never in albumUsers – check ownerId/owner.id directly
+	// v2: check ownerId / owner.id directly
 	if (store.currentAlbum.ownerId === store.currentUserId
 		|| store.currentAlbum.owner?.id === store.currentUserId) return 'owner'
+	// v3 (and v2 fallback): role is in albumUsers
 	const entry = store.currentAlbum.albumUsers?.find(u => u.user?.id === store.currentUserId)
 	if (entry !== undefined) return entry.role
 	return 'viewer'

--- a/src/components/AlbumDetailView.vue
+++ b/src/components/AlbumDetailView.vue
@@ -1,5 +1,12 @@
 <!--
-  - SPDX-FileCopyrightText: 202					<NcButton v-if="totalCount > 0"
+  - SPDX-FileCopyrightText: 202							<NcButton v-if="canEdit && totalCount > 0"
+						variant="secondary"
+						@click="showPicker = true">
+						<template #icon>
+							<ImagePlusIcon :size="20" />
+						</template>
+						{{ t('integration_immich', 'Add photos') }}
+					</NcButton>tton v-if="totalCount > 0"
 						variant="secondary"
 						@click="showPicker = true">arcel Meyer <gh@grenzallee.eu>
   - SPDX-License-Identifier: AGPL-3.0-or-later
@@ -210,15 +217,15 @@ const renaming = ref(false)
 
 /**
  * The current Immich user's role in this album.
- * Important: Immich does NOT put the owner into albumUsers – that array only
- * contains users the album was shared WITH. The owner is identified via
- * album.ownerId / album.owner.id.
+ * v2: owner is identified via album.ownerId / album.owner.id (never in albumUsers).
+ * v3: ownerId/owner were removed; the owner is now in albumUsers with role 'owner'.
  */
 const myRole = computed(() => {
 	if (!store.currentUserId || !store.currentAlbum) return 'viewer'
-	// Owner is never in albumUsers – check ownerId/owner.id directly
+	// v2: check ownerId / owner.id directly
 	if (store.currentAlbum.ownerId === store.currentUserId
 		|| store.currentAlbum.owner?.id === store.currentUserId) return 'owner'
+	// v3 (and v2 fallback): role is in albumUsers
 	const entry = store.currentAlbum.albumUsers?.find(u => u.user?.id === store.currentUserId)
 	if (entry !== undefined) return entry.role
 	return 'viewer'
@@ -254,9 +261,18 @@ const totalCount = computed(() =>
 )
 
 // IDs der bereits im Album enthaltenen Assets → werden im Picker grau markiert
-const existingAssetIds = computed(() =>
-	new Set((store.currentAlbum?.assets ?? []).map(a => a.id))
-)
+// v2: album.assets was part of AlbumResponseDto (removed in v3).
+// v3 fallback: collect IDs from the already-loaded album timeline bucket assets.
+const existingAssetIds = computed(() => {
+	if (store.currentAlbum?.assets) {
+		return new Set(store.currentAlbum.assets.map(a => a.id))
+	}
+	const ids = new Set()
+	for (const assets of Object.values(store.albumBucketAssets)) {
+		for (const a of assets) ids.add(a.id)
+	}
+	return ids
+})
 
 function estimateBucketHeight(count) {
 	const available = Math.max(GRID_MIN_ITEM, containerWidth.value - BUCKET_PADDING_LR)

--- a/src/components/AlbumDetailView.vue
+++ b/src/components/AlbumDetailView.vue
@@ -1,14 +1,5 @@
 <!--
-  - SPDX-FileCopyrightText: 202							<NcButton v-if="canEdit && totalCount > 0"
-						variant="secondary"
-						@click="showPicker = true">
-						<template #icon>
-							<ImagePlusIcon :size="20" />
-						</template>
-						{{ t('integration_immich', 'Add photos') }}
-					</NcButton>tton v-if="totalCount > 0"
-						variant="secondary"
-						@click="showPicker = true">arcel Meyer <gh@grenzallee.eu>
+  - SPDX-FileCopyrightText: 2026 Marcel Meyer <gh@grenzallee.eu>
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
@@ -43,7 +34,7 @@
 							</template>
 							{{ t('integration_immich', 'Rename') }}
 						</NcButton>
-						<NcButton v-if="canEdit && store.currentAlbum.assets && store.currentAlbum.assets.length > 0"
+						<NcButton v-if="canEdit && totalCount > 0"
 							variant="secondary"
 							@click="showPicker = true">
 							<template #icon>

--- a/src/components/AlbumsView.vue
+++ b/src/components/AlbumsView.vue
@@ -171,7 +171,7 @@ const deleting = ref(false)
  * v3: ownerId/owner were removed; the owner is now in albumUsers with role 'owner'.
  */
 function isOwnedByMe(album) {
-	if (!store.currentUserId) return !album.shared
+	if (!store.currentUserId) return false
 	// v2: check ownerId / owner.id directly
 	if (album.ownerId === store.currentUserId || album.owner?.id === store.currentUserId) return true
 	// v3 (and v2 fallback): owner appears in albumUsers with role 'owner'

--- a/src/components/AlbumsView.vue
+++ b/src/components/AlbumsView.vue
@@ -167,15 +167,14 @@ const deleting = ref(false)
 /**
  * Returns true if the currently authenticated Immich user is the owner of the
  * given album.
- * Important: Immich does NOT put the owner into albumUsers – that array only
- * contains users the album was shared WITH. The owner is identified via
- * album.ownerId / album.owner.id.
+ * v2: owner is identified via album.ownerId / album.owner.id (never in albumUsers).
+ * v3: ownerId/owner were removed; the owner is now in albumUsers with role 'owner'.
  */
 function isOwnedByMe(album) {
 	if (!store.currentUserId) return !album.shared
-	// Check ownerId directly – the owner is never in albumUsers
+	// v2: check ownerId / owner.id directly
 	if (album.ownerId === store.currentUserId || album.owner?.id === store.currentUserId) return true
-	// Fallback: check albumUsers in case API behaviour ever changes
+	// v3 (and v2 fallback): owner appears in albumUsers with role 'owner'
 	const myEntry = album.albumUsers?.find(u => u.user?.id === store.currentUserId)
 	if (myEntry !== undefined) return myEntry.role === 'owner'
 	return false
@@ -186,10 +185,12 @@ function isOwnedByMe(album) {
  */
 function myRoleIn(album) {
 	if (!store.currentUserId) return null
-	// Owner is never in albumUsers – return null (no shared-role badge for own albums)
+	// v2: owner is identified via ownerId / owner.id – never in albumUsers
 	if (album.ownerId === store.currentUserId || album.owner?.id === store.currentUserId) return null
 	const entry = album.albumUsers?.find(u => u.user?.id === store.currentUserId)
 	if (!entry) return null
+	// v3: owner is now included in albumUsers with role 'owner' – suppress badge for own albums
+	if (entry.role === 'owner') return null
 	return entry.role
 }
 


### PR DESCRIPTION
## Summary

This PR addresses findings from a code review of the v2/v3 dual-compatibility work.

### Fixes

#### 🟡 `ImmichService::uploadAsset()` — HTTP error handling
Add `http_errors => false` and an explicit HTTP status check, consistent with `requestBinary()` and `requestBinaryPost()`. Previously, any 4xx/5xx from Immich (e.g. 401 expired key, 413 payload too large, 409 duplicate) caused an opaque Guzzle exception. The status code is now logged and re-thrown with a clear message.

#### ✅ `AlbumDetailView` — Guard 'Add photos' button with `canEdit`
Previously visible to viewers of shared albums. The server enforced the permission, but the button was misleading. Changed `v-if="totalCount > 0"` to `v-if="canEdit && totalCount > 0"`.

#### ✅ `AlbumsView` — Suppress 'Shared (Owner)' badge on v3
On Immich v3, the album owner now appears in `albumUsers` with `role: 'owner'`. Without the `entry.role === 'owner'` guard, own albums displayed a 'Shared (Owner)' badge.

#### ✅ `AlbumDetailView` — `existingAssetIds` fallback for v3
`album.assets` was removed in Immich v3. Fall back to collecting IDs from already-loaded bucket assets so the picker can still gray-out duplicates.

#### ✅ `ImmichService::getAlbums()` — v2/v3 filter params
Send both v2 (`shared`) and v3 (`isOwned`/`isShared`) filter params in each albums request. Each Immich version reads what it knows and ignores the rest.

#### ✅ `ImmichService::searchByLocation()` — explicit `visibility`
v3 changed the default for omitted `visibility` from `'timeline'` to `'all'`. Set it explicitly to exclude archived/locked assets on both versions.

#### ✅ Documentation
Improved comments across `ImmichService`, `App.vue`, `AlbumDetailView.vue`, and `AlbumsView.vue` to document v2 vs v3 API differences.

## What was NOT changed
- **v2 regression for owned-and-shared albums**: On v2, albums the user owns AND has shared with others may appear after shared-with-you albums in the list. Accepted limitation — v2 usage is rare and this is display-order only, not a data or security issue.
